### PR TITLE
OY2 23720: Update OneMAC packages from SEATool Delete notifications

### DIFF
--- a/services/one-stream/handleOneStream.js
+++ b/services/one-stream/handleOneStream.js
@@ -51,6 +51,11 @@ export const main = async (eventBatch) => {
             break;
           case "SEATool": {
             const [, topic] = newEventData.GSI1pk.S.split("#");
+            if (newEventData.seaToolDelete.S === "true") {
+              packageToBuild.type = "delete";
+              break;
+            }
+
             let actionType;
             console.log("%s ACTIONTYPES: ", inPK, newEventData.ACTIONTYPES);
             if (!newEventData.ACTIONTYPES.NULL)
@@ -109,6 +114,9 @@ export const main = async (eventBatch) => {
           return;
         }
         switch (packageToBuild.type) {
+          case "delete":
+            console.log("%s got a delete for package", inPK, packageToBuild);
+            break;
           case Workflow.ONEMAC_TYPE.CHIP_SPA:
           case Workflow.ONEMAC_TYPE.CHIP_SPA_RAI:
           case Workflow.ONEMAC_TYPE.CHIP_SPA_WITHDRAW:

--- a/services/one-stream/package/deletePackage.js
+++ b/services/one-stream/package/deletePackage.js
@@ -1,8 +1,6 @@
-const _ = require("lodash");
 import AWS from "aws-sdk";
-import { DateTime } from "luxon";
 
-import { dynamoConfig, Workflow } from "cmscommonlib";
+import { dynamoConfig } from "cmscommonlib";
 
 const dynamoDb = new AWS.DynamoDB.DocumentClient(dynamoConfig);
 
@@ -35,7 +33,7 @@ export const deletePackage = async (packageId) => {
           Item: {
             ...item,
             pk: "DELETED_ITEMS",
-            sk: `${pk}#${item.sk}`,
+            sk: `${item.pk}#${item.sk}`,
           },
         };
         await dynamoDb.put(putParams).promise();

--- a/services/one-stream/package/deletePackage.js
+++ b/services/one-stream/package/deletePackage.js
@@ -1,0 +1,62 @@
+const _ = require("lodash");
+import AWS from "aws-sdk";
+import { DateTime } from "luxon";
+
+import { dynamoConfig, Workflow } from "cmscommonlib";
+
+const dynamoDb = new AWS.DynamoDB.DocumentClient(dynamoConfig);
+
+const oneMacTableName = process.env.IS_OFFLINE
+  ? process.env.localTableName
+  : process.env.oneMacTableName;
+
+export const deletePackage = async (packageId) => {
+  console.log("deleting package: ", packageId);
+  const queryParams = {
+    TableName: oneMacTableName,
+    KeyConditionExpression: "pk = :pk",
+    ExpressionAttributeValues: {
+      ":pk": packageId,
+    },
+  };
+  console.log("%s the new query params are: ", packageId, queryParams);
+
+  try {
+    const result = await dynamoDb.query(queryParams).promise();
+    console.log("%s query result: ", packageId, result);
+    if (result?.Items.length <= 0) {
+      console.log("%s did not have Items?", packageId);
+      return;
+    }
+    await Promise.all(
+      result.Items.map(async (item) => {
+        const putParams = {
+          TableName: oneMacTableName,
+          Item: {
+            ...item,
+            pk: "DELETED_ITEMS",
+            sk: `${pk}#${item.sk}`,
+          },
+        };
+        await dynamoDb.put(putParams).promise();
+      })
+    );
+
+    await Promise.all(
+      result.Items.map(async (item) => {
+        const deleteParams = {
+          TableName: oneMacTableName,
+          Key: {
+            pk: item.pk,
+            sk: item.sk,
+          },
+        };
+
+        await dynamoDb.delete(deleteParams).promise();
+      })
+    );
+  } catch (e) {
+    console.log("%s deletePackage error: ", packageId, e);
+  }
+  console.log("%s the end of things", packageId);
+};

--- a/services/seatool-sink/handlers/seaToolEvent.js
+++ b/services/seatool-sink/handlers/seaToolEvent.js
@@ -12,6 +12,7 @@ function myHandler(event) {
   console.log("Received event:", JSON.stringify(event, null, 2));
   const topicName = event.topic.replace(topicPrefix, "");
   const value = event?.value ? JSON.parse(event.value) : event;
+  if (!event?.value) value.seaToolDelete = "true";
   console.log(`Type: ${topicName} Topic: ${event.topic}`);
 
   const pk = event.key.toUpperCase();

--- a/services/seatool-sink/handlers/seaToolEvent.js
+++ b/services/seatool-sink/handlers/seaToolEvent.js
@@ -11,8 +11,7 @@ function myHandler(event) {
   }
   console.log("Received event:", JSON.stringify(event, null, 2));
   const topicName = event.topic.replace(topicPrefix, "");
-  const value =
-    event.value !== "" ? JSON.parse(event.value) : JSON.parse(event);
+  const value = event?.value ? JSON.parse(event.value) : event;
   console.log(`Type: ${topicName} Topic: ${event.topic}`);
 
   const pk = event.key.toUpperCase();

--- a/services/seatool-sink/handlers/seaToolEvent.js
+++ b/services/seatool-sink/handlers/seaToolEvent.js
@@ -11,18 +11,18 @@ function myHandler(event) {
   }
   console.log("Received event:", JSON.stringify(event, null, 2));
   const topicName = event.topic.replace(topicPrefix, "");
-  const value = JSON.parse(event.value);
+  const value = event.value ? JSON.parse(event.value) : JSON.parse(event);
   console.log(`Type: ${topicName} Topic: ${event.topic}`);
 
-  const pk = value.STATE_PLAN.ID_NUMBER.toUpperCase();
-  const changedDate = value.STATE_PLAN.CHANGED_DATE;
+  const pk = event.key.toUpperCase();
+  const changedDate = value?.STATE_PLAN?.CHANGED_DATE || value.timestamp;
   if (!pk || !changedDate) return;
 
   // use the offset as a version number/event tracker... highest id is most recent
   const sk = `SEATool#${changedDate}`;
 
   const GSI1pk = `SEATool#${topicName}`;
-  const GSI1sk = value.STATE_PLAN.ID_NUMBER.toUpperCase();
+  const GSI1sk = pk;
 
   // put the SEATool Entry - don't bother if already exists
   const updateSEAToolParams = {

--- a/services/seatool-sink/handlers/seaToolEvent.js
+++ b/services/seatool-sink/handlers/seaToolEvent.js
@@ -11,7 +11,8 @@ function myHandler(event) {
   }
   console.log("Received event:", JSON.stringify(event, null, 2));
   const topicName = event.topic.replace(topicPrefix, "");
-  const value = event.value ? JSON.parse(event.value) : JSON.parse(event);
+  const value =
+    event.value !== "" ? JSON.parse(event.value) : JSON.parse(event);
   console.log(`Type: ${topicName} Topic: ${event.topic}`);
 
   const pk = event.key.toUpperCase();


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-23720
Endpoint: See github-actions bot comment

### Details
When a package is deleted from SEA Tool, we get a null event for that package.  OneMAC needs to read that event and perform the delete action.
Deleting means that the package is no longer visible in OneMAC dashboards, and the ID is reusable.
Auditing requires that we keep the package details as well as the information about the deletion.

### Changes
- updated the seatool-sink to recognize and flag a delete event from SEA Tool
- updated handleOneStream to recognize the delete flag and call the delete function
- created deletePackage function which takes a package ID and pushes all events for that ID into the 

### Implementation Notes
- 

### Test Plan
1. Test step 1
2. Test step 2
