### PR TITLE
OY2 24006: Update 1915(b) Waiver Text

### DIFF
--- a/services/ui-src/src/libs/faq/faqContent.tsx
+++ b/services/ui-src/src/libs/faq/faqContent.tsx
@@ -603,9 +603,9 @@ export const oneMACFAQContent: FAQContent[] = [
                     application pre-print (Initial, Renewal, Amendment)
                   </td>
                   <td>
-                    State submission of the 1915(b)(4) FFS Selective Contracting
-                    Waiver Fee-for-Service Selective Contracting Program
-                    preprint narrative (Sections A, B, and C)
+                    State submission of the 1915(b)(4) Fee-for-Service Selective
+                    Contracting Program preprint narrative (Sections A, B, and
+                    C)
                   </td>
                 </tr>
                 <tr>

--- a/services/ui-src/src/libs/faq/faqContent.tsx
+++ b/services/ui-src/src/libs/faq/faqContent.tsx
@@ -603,9 +603,9 @@ export const oneMACFAQContent: FAQContent[] = [
                     application pre-print (Initial, Renewal, Amendment)
                   </td>
                   <td>
-                    State submission of the 1915(b)(4) Fee-for-Service Selective
-                    Contracting Program preprint narrative (Sections A, B, and
-                    C)
+                    State submission of the 1915(b)(4) Waiver Fee-for-Service
+                    Selective Contracting Program preprint narrative (Sections
+                    A, B, and C)
                   </td>
                 </tr>
                 <tr>

--- a/services/ui-src/src/libs/faq/faqContent.tsx
+++ b/services/ui-src/src/libs/faq/faqContent.tsx
@@ -603,9 +603,9 @@ export const oneMACFAQContent: FAQContent[] = [
                     application pre-print (Initial, Renewal, Amendment)
                   </td>
                   <td>
-                    State submission of the 1915(b)(4) Waiver Fee-for-Service
-                    Selective Contracting Program preprint narrative (Sections
-                    A, B, and C)
+                    State submission of the 1915(b)(4) FFS Selective Contracting
+                    Waiver Fee-for-Service Selective Contracting Program
+                    preprint narrative (Sections A, B, and C)
                   </td>
                 </tr>
                 <tr>

--- a/services/ui-src/src/libs/triageChoices.js
+++ b/services/ui-src/src/libs/triageChoices.js
@@ -56,60 +56,69 @@ export const choicesFromRoute = {
     ],
   },
   [ONEMAC_ROUTES.TRIAGE_WAIVER_B]: {
-    heading: "1915(b)(4) Waiver Action Type",
+    heading: "1915(b) Waiver Action Type",
     intro: "Select a 1915(b) Waiver type for your submission.",
     choices: [
       {
-        title: "1915(b)(4) FFS Selective Contracting waivers",
-        description: "Submit 1915(b)(4) Waivers, Amendments, and Renewals",
+        title: "1915(b)(4) FFS Selective Contracting Waivers",
+        description:
+          "Submit 1915(b)(4) FFS Selective Contracting Waivers, Amendments, and Renewals",
         linkTo: ONEMAC_ROUTES.TRIAGE_WAIVER_B_4,
       },
       {
-        title: "All Other 1915(b) Waiver Authority",
-        description: "Submit 1915(b) Waivers, Amendments, and Renewals",
-        strongText: "Not applicable for 1915(b)(4) waiver actions",
+        title: "1915(b) Comprehensive (Capitated) Waiver Authority",
+        description:
+          "Submit 1915(b) Comprehensive (Capitated) Waivers, Amendments, and Renewals",
+        strongText:
+          "Not applicable for 1915(b)(4) FFS Selective Contracting Waiver actions",
         linkTo: ONEMAC_ROUTES.TRIAGE_WAIVER_B_OTHER,
       },
     ],
   },
   [ONEMAC_ROUTES.TRIAGE_WAIVER_B_4]: {
-    heading: "1915(b)(4) Waiver Authority",
+    heading: "1915(b)(4) FFS Selective Contracting Waiver Authority",
     intro: "Select a Waiver type to start your submission.",
     choices: [
       {
-        title: "1915(b)(4) New Initial Waiver",
-        description: "Create a new 1915(b)(4) initial waiver",
+        title: "1915(b)(4) FFS Selective Contracting New Initial Waiver",
+        description:
+          "Create a new 1915(b)(4) FFS Selective Contracting Initial Waiver",
         linkTo: ONEMAC_ROUTES.INITIAL_WAIVER_B_4,
       },
       {
-        title: "1915(b)(4) Renewal Waiver",
-        description: "Renew an existing 1915(b)(4) waiver",
+        title: "1915(b)(4) FFS Selective Contracting Renewal Waiver",
+        description:
+          "Renew an existing 1915(b)(4) FFS Selective Contracting Waiver",
         linkTo: ONEMAC_ROUTES.WAIVER_RENEWAL_B_4,
       },
       {
-        title: "1915(b)(4) Amendment",
-        description: "Amend an existing 1915(b)(4) waiver",
+        title: "1915(b)(4) FFS Selective Contracting Waiver Amendment",
+        description:
+          "Amend an existing 1915(b)(4) FFS Selective Contracting Waiver",
         linkTo: ONEMAC_ROUTES.WAIVER_AMENDMENT_B_4,
       },
     ],
   },
   [ONEMAC_ROUTES.TRIAGE_WAIVER_B_OTHER]: {
-    heading: "All Other 1915(b) Waiver Authority",
+    heading: "1915(b) Comprehensive (Capitated) Waiver Authority",
     intro: "Select a Waiver type to start your submission.",
     choices: [
       {
-        title: "1915(b) New Initial Waiver",
-        description: "Create a new 1915(b) initial waiver",
+        title: "1915(b) Comprehensive (Capitated) New Initial Waiver",
+        description:
+          "Create a new 1915(b) Comprehensive (Capitated) Initial Waiver",
         linkTo: ONEMAC_ROUTES.INITIAL_WAIVER_B_OTHER,
       },
       {
-        title: "1915(b) Renewal Waiver",
-        description: "Renew an existing 1915(b) waiver",
+        title: "1915(b) Comprehensive (Capitated) Renewal Waiver",
+        description:
+          "Renew an existing 1915(b) Comprehensive (Capitated) Waiver",
         linkTo: ONEMAC_ROUTES.WAIVER_RENEWAL_B_OTHER,
       },
       {
-        title: "1915(b) Amendment",
-        description: "Amend an existing 1915(b) waiver",
+        title: "1915(b) Comprehensive (Capitated) Waiver Amendment",
+        description:
+          "Amend an existing 1915(b) Comprehensive (Capitated) Waiver",
         linkTo: ONEMAC_ROUTES.WAIVER_AMENDMENT_B_OTHER,
       },
     ],


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24006
Endpoint: See github-actions bot comment

### Details
Apparently the Business Owners (not Rachel and Jaime) changed their minds about what text needed to be on the choice cards.

### Changes
- 1915(b)(4) should never be without "FFS Selective Contracting"
- 1915(b) "Other" is not other, but is "1915(b) Comprehensive (Capitated)"

### Test Plan
1. Log in as a submitting user
2. Verify text changes
3. Jaime and Rachel will be given a demo after peer review and before this goes into testing.
