### PR TITLE
Lambda Refactor: Rebuild packages

### DIFF
--- a/services/one-stream/processPackages.js
+++ b/services/one-stream/processPackages.js
@@ -1,0 +1,92 @@
+import AWS from "aws-sdk";
+
+import { dynamoConfig } from "cmscommonlib";
+
+const dynamoDb = new AWS.DynamoDB.DocumentClient(dynamoConfig);
+
+const oneMacTableName = process.env.IS_OFFLINE
+  ? process.env.localTableName
+  : process.env.oneMacTableName;
+
+export const main = async () => {
+  // get the process status information from dynamodb
+  const processParams = {
+    TableName: oneMacTableName,
+    KeyConditionExpression: "pk = :pk",
+    ExpressionAttributeValues: {
+      ":pk": "Process",
+    },
+  };
+  console.log("processParams: ", processParams);
+  const pResults = await dynamoDb.query(processParams).promise();
+
+  console.log("pResults: ", pResults);
+  const toRebuild = [];
+
+  await Promise.all(
+    pResults.Items.map(async (pItem) => {
+      console.log("processing item: ", pItem);
+      // need the parameters inside the scope of the Promise
+      const queryGSI1Params = {
+        TableName: oneMacTableName,
+        IndexName: "GSI1",
+        KeyConditionExpression: "GSI1pk = :pk",
+        ExpressionAttributeValues: {
+          ":pk": pItem.sk,
+        },
+        ProjectionExpression: "pk, sk",
+      };
+      if (pItem.processStartKey)
+        queryGSI1Params.ExclusiveStartKey = pItem.processStartKey;
+
+      console.log(`queryGSI1Params: %s`, queryGSI1Params);
+      const results = await dynamoDb.query(queryGSI1Params).promise();
+      console.log("results: ", results);
+      toRebuild.push(...results.Items);
+
+      if (results.LastEvaluatedKey) {
+        const nextProcessParams = {
+          TableName: oneMacTableName,
+          Key: {
+            pk: pItem.pk,
+            sk: pItem.sk,
+          },
+          Item: {
+            ...pItem,
+            processStartKey: results.LastEvaluatedKey,
+          },
+        };
+        await dynamoDb.put(nextProcessParams).promise();
+      } else {
+        const deleteProcessParams = {
+          TableName: oneMacTableName,
+          Key: {
+            pk: pItem.pk,
+            sk: pItem.sk,
+          },
+        };
+
+        await dynamoDb.delete(deleteProcessParams).promise();
+      }
+    })
+  );
+
+  console.log("toRebuild: ", toRebuild);
+  await Promise.all(
+    toRebuild.map(async (item) => {
+      await dynamoDb
+        .update({
+          TableName: oneMacTableName,
+          Key: {
+            pk: item.pk,
+            sk: item.sk,
+          },
+          UpdateExpression: "SET streamUpdateDate = :dt",
+          ExpressionAttributeValues: {
+            ":dt": Date.now(),
+          },
+        })
+        .promise();
+    })
+  );
+};

--- a/services/one-stream/rebuildPackages.js
+++ b/services/one-stream/rebuildPackages.js
@@ -4,59 +4,29 @@ import { dynamoConfig } from "cmscommonlib";
 
 const dynamoDb = new AWS.DynamoDB.DocumentClient(dynamoConfig);
 
-const gsi1pksToRebuild = [
+const topicsToRebuild = [
   "SEATool#Medicaid_SPA",
   "SEATool#CHIP_SPA",
   "SEATool#1915b_waivers",
   "SEATool#1915c_waivers",
 ];
 
-export const main = async () => {
-  // only run this if indicated in the deploy
-  if (!process.env.deployTrigger || process.env.deployTrigger === "none")
-    return;
+const oneMacTableName = process.env.IS_OFFLINE
+  ? process.env.localTableName
+  : process.env.oneMacTableName;
 
-  const toRebuild = [];
-
+export const main = async (event) => {
   await Promise.all(
-    gsi1pksToRebuild.map(async (gsi1pk) => {
-      // need the parameters inside the scope of the Promise
-      const queryGSI1Params = {
-        TableName: process.env.oneMacTableName,
-        IndexName: "GSI1",
-        KeyConditionExpression: "GSI1pk = :pk",
-        ExpressionAttributeValues: {
-          ":pk": gsi1pk,
+    topicsToRebuild.map(async (oneTopic) => {
+      const processParams = {
+        TableName: oneMacTableName,
+        Item: {
+          pk: "Process",
+          sk: oneTopic,
+          reason: event.reason,
         },
-        ProjectionExpression: "pk, sk",
       };
-
-      do {
-        console.log(`queryGSI1Params: %s`, queryGSI1Params);
-        const results = await dynamoDb.query(queryGSI1Params).promise();
-        console.log("results: ", results);
-        toRebuild.push(...results.Items);
-        queryGSI1Params.ExclusiveStartKey = results.LastEvaluatedKey;
-      } while (queryGSI1Params.ExclusiveStartKey);
-    })
-  );
-
-  console.log("toRebuild: ", toRebuild);
-  await Promise.all(
-    toRebuild.map(async (item) => {
-      await dynamoDb
-        .update({
-          TableName: process.env.oneMacTableName,
-          Key: {
-            pk: item.pk,
-            sk: item.sk,
-          },
-          UpdateExpression: "SET deployTrigger = :dt",
-          ExpressionAttributeValues: {
-            ":dt": process.env.deployTrigger,
-          },
-        })
-        .promise();
+      await dynamoDb.put(processParams).promise();
     })
   );
 };

--- a/services/one-stream/serverless.yml
+++ b/services/one-stream/serverless.yml
@@ -70,7 +70,7 @@ functions:
       localTableName: ${self:custom.localTableName}
     maximumRetryAttempts: 2
 
-processPackages:
+  processPackages:
     handler: processPackages.main
     role: LambdaOneStreamRole
     environment:
@@ -83,7 +83,7 @@ processPackages:
           rate: rate(2 minutes)
     timeout: 600
 
-rebuildPackages:
+  rebuildPackages:
     handler: rebuildPackages.main
     role: LambdaOneStreamRole
     environment:

--- a/services/one-stream/serverless.yml
+++ b/services/one-stream/serverless.yml
@@ -70,6 +70,19 @@ functions:
       localTableName: ${self:custom.localTableName}
     maximumRetryAttempts: 2
 
+processPackages:
+    handler: processPackages.main
+    role: LambdaOneStreamRole
+    environment:
+      STAGE: ${self:custom.stage}
+      oneMacTableName: ${self:custom.oneMacTableName}
+      localTableName: ${self:custom.localTableName}
+    maximumRetryAttempts: 2
+    events:
+      - schedule:
+          rate: rate(2 minutes)
+    timeout: 600
+
   rebuildPackages:
     handler: rebuildPackages.main
     role: LambdaOneStreamRole
@@ -77,7 +90,6 @@ functions:
       STAGE: ${self:custom.stage}
       oneMacTableName: ${self:custom.oneMacTableName}
       localTableName: ${self:custom.localTableName}
-      deployTrigger: "rebuild to add Subject and Description to packages"
     maximumRetryAttempts: 2
     timeout: 600
 

--- a/services/one-stream/serverless.yml
+++ b/services/one-stream/serverless.yml
@@ -83,7 +83,7 @@ processPackages:
           rate: rate(2 minutes)
     timeout: 600
 
-  rebuildPackages:
+rebuildPackages:
     handler: rebuildPackages.main
     role: LambdaOneStreamRole
     environment:


### PR DESCRIPTION
Story: Lambda Refactor
Endpoint: See github-actions bot comment

### Details
the rebuildPackages lambda is supposed to go through all the SEA Tool topics and update them such that the packages get rebuilt.  However, it quickly reaches a write throttling threshold, so is unreliable.

### Changes
- created a scheduled lambda that looks for "jobs" and runs them
- rebuild packages now adds jobs to the queue

### Implementation Notes
- I guessed with many of the variables, so might need tweaking, either to speed up the rebuild, or if we hit the threshold again.

### Test Plan
1. Login to AWS Console
2. Go to the lambda console for one-stream-rebuild-packages-rebuildPackages
3. Navigate to Test tab
4. add "reason": "testing" (can be any reason, really) to the test event
5. run the test
6. Verify that the Process items have been added to the one table
7. Verify that processPackages picks up the Process items, runs, then updates the Process items with the new start keys
8. Try to watch for throttling issues or if anything isn't working (I know, sorry!)
