### PR TITLE
TE details should not have Review Team

### DIFF
--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -2227,7 +2227,33 @@
       }
     ],
     "sk": "SEATool#1672291818177",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -2511,7 +2537,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1672291244320",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -2718,7 +2770,57 @@
     ],
     "RAI": null,
     "sk": "SEATool#1672291290683",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+    "EMAIL": "lesterT2@example.gov",
+    "FIRST_NAME": "Lester2",
+    "INITIALS": null,
+    "LAST_NAME": "Tester",
+    "OFFICER_ID": 3743,
+    "POSITION_ID": 538,
+    "TELEPHONE": "(410) 555-5445"
+   },{
+    "EMAIL": "SuperT2@example.gov",
+    "FIRST_NAME": "Super2",
+    "INITIALS": null,
+    "LAST_NAME": "Tester",
+    "OFFICER_ID": 3744,
+    "POSITION_ID": 538,
+    "TELEPHONE": "(410) 555-5445"
+   },{
+    "EMAIL": "jimmyT2@example.gov",
+    "FIRST_NAME": "Jimmy2",
+    "INITIALS": null,
+    "LAST_NAME": "Tester",
+    "OFFICER_ID": 3745,
+    "POSITION_ID": 538,
+    "TELEPHONE": "(410) 555-5445"
+   }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -3008,7 +3110,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1672415524800",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -3211,7 +3339,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1672418237963",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -3769,7 +3923,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673560321983",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -4084,7 +4264,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1673561667690",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -4385,7 +4591,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673561723710",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -4614,7 +4846,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1673561904343",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -4915,7 +5173,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673562045143",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -5144,7 +5428,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1673562102227",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -5369,7 +5679,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1677001577403",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -5594,7 +5930,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1677004716873",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -5895,7 +6257,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673560383883",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -6124,7 +6512,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1673560540373",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": [
       {
@@ -6441,7 +6855,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673563526240",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -7039,7 +7479,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673563881220",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -7284,7 +7750,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1676470945530",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -7510,7 +8002,33 @@
       }
     ],
     "sk": "SEATool#1676471000990",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -7740,7 +8258,33 @@
       }
     ],
     "sk": "SEATool#1676477951800",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -8008,7 +8552,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1676387239307",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -8215,7 +8785,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1676387312330",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -8499,7 +9095,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673562912250",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -8710,7 +9332,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1673562987470",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -8994,7 +9642,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673563103150",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -9205,7 +9879,33 @@
       }
     ],
     "sk": "SEATool#1673563146807",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -9489,7 +10189,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673563200377",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -10017,7 +10743,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674138255257",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -10228,7 +10980,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674138322323",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -10482,7 +11260,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1676470945530",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -10696,7 +11500,33 @@
       }
     ],
     "sk": "SEATool#1676471000990",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -10929,7 +11759,33 @@
       }
     ],
     "sk": "SEATool#1676477951800",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -11232,7 +12088,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674138977880",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -12032,7 +12914,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674139179923",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -12239,7 +13147,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674139250720",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -12546,7 +13480,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674158363023",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -12759,7 +13719,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674158420033",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -12977,7 +13963,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674158680503",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -13240,7 +14252,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673565094600",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -13457,7 +14495,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1673565127960",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -13720,7 +14784,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674139738723",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -13937,7 +15027,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674139803363",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -14329,7 +15445,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1672953739920",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -16978,7 +18120,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673560789160",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -17491,7 +18659,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674139971877",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -17708,7 +18902,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674140031527",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -17983,7 +19203,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674140082590",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -18207,7 +19453,33 @@
       }
     ],
     "sk": "SEATool#1674140129073",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -18470,7 +19742,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674140212790",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -18691,7 +19989,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674140942997",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -18980,7 +20304,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674243123300",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -19193,7 +20543,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674243148410",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -19456,7 +20832,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673565420973",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -19719,7 +21121,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674141102640",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -19936,7 +21364,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674141136500",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -20213,7 +21667,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674141217987",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -20490,7 +21970,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674141288737",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -20767,7 +22273,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674141390750",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -21036,7 +22568,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674141437213",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -21260,7 +22818,33 @@
       }
     ],
     "sk": "SEATool#1674141495920",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -21523,7 +23107,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673625786593",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -21725,7 +23335,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674141711257",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -24032,7 +25668,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674224708607",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -24245,7 +25907,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674224750490",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -24467,7 +26155,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674243800610",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -24689,7 +26403,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674243913907",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -25026,7 +26766,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674152238197",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -25239,7 +27005,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674152410900",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -25456,7 +27248,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674153029957",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -25677,7 +27495,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674153159127",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -25902,7 +27746,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674153253613",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -26131,7 +28001,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674153309863",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -27483,7 +29379,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674224793650",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -27696,7 +29618,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674224830653",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -27959,7 +29907,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674224972157",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -28183,7 +30157,33 @@
       }
     ],
     "sk": "SEATool#1674225014557",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -28446,7 +30446,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1672851468730",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -28659,7 +30685,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1672851524537",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -28882,7 +30934,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1672851850657",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -29109,7 +31187,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674143333263",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -29355,7 +31459,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674244333420",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -29605,7 +31735,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674244379640",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -29855,7 +32011,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674244390463",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -30109,7 +32291,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674244460090",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -30363,7 +32571,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674244533133",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -30643,7 +32877,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674225131087",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -30860,7 +33120,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674225171163",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -31123,7 +33409,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674225720270",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -31340,7 +33652,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674225774200",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -31603,7 +33941,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674225804713",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -31820,7 +34184,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674225853030",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -32089,7 +34479,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674225880623",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -32634,7 +35050,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674656568887",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -32847,7 +35289,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674656606380",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -33108,7 +35576,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673566133010",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -33417,7 +35911,33 @@
       }
     ],
     "sk": "SEATool#1674147387493",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -33704,7 +36224,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674147128737",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -34720,7 +37266,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674226040180",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -34937,7 +37509,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674226106857",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -35225,7 +37823,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1672783219867",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -35438,7 +38062,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1672783434973",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -35662,7 +38312,33 @@
       }
     ],
     "sk": "SEATool#1672783851453",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -35890,7 +38566,33 @@
       }
     ],
     "sk": "SEATool#1674226188617",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -36178,7 +38880,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674226307757",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -36395,7 +39123,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674226356523",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -36683,7 +39437,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673625410180",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -37978,7 +40758,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1674656635480",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -38191,7 +40997,33 @@
     ],
     "RAI": null,
     "sk": "SEATool#1674656687933",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -38454,7 +41286,33 @@
     "STATE_PLAN_SERVICE_SUBTYPES": null,
     "RAI": null,
     "sk": "SEATool#1673565420973",
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "SP1115": null,
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
@@ -38531,7 +41389,33 @@
       "PLAN_TYPE_ID": 123
      }
     ],
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "CALLHELDREASONS": null,
     "CODEAFTERINITACCESS": null,
     "COMPONENTS": [
@@ -38694,7 +41578,33 @@
       "PLAN_TYPE_ID": 123
      }
     ],
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "CALLHELDREASONS": [
      {
       "CALL_HELD_REASON_ID": 4,
@@ -38973,7 +41883,33 @@
       "PLAN_TYPE_ID": 123
      }
     ],
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "CALLHELDREASONS": null,
     "CODEAFTERINITACCESS": null,
     "COMPONENTS": [
@@ -39136,7 +42072,33 @@
       "PLAN_TYPE_ID": 123
      }
     ],
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "CALLHELDREASONS": null,
     "CODEAFTERINITACCESS": null,
     "COMPONENTS": [
@@ -39299,7 +42261,33 @@
       "PLAN_TYPE_ID": 123
      }
     ],
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "CALLHELDREASONS": null,
     "CODEAFTERINITACCESS": null,
     "COMPONENTS": [
@@ -39609,7 +42597,33 @@
       "PLAN_TYPE_ID": 123
      }
     ],
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "CALLHELDREASONS": [
      {
       "CALL_HELD_REASON_ID": 1,
@@ -39924,7 +42938,33 @@
       "PLAN_TYPE_ID": 122
      }
     ],
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "CALLHELDREASONS": null,
     "CODEAFTERINITACCESS": null,
     "COMPONENTS": [
@@ -40087,7 +43127,33 @@
       "PLAN_TYPE_ID": 122
      }
     ],
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "CALLHELDREASONS": null,
     "CODEAFTERINITACCESS": null,
     "COMPONENTS": null,
@@ -40498,7 +43564,33 @@
       "PLAN_TYPE_ID": 122
      }
     ],
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "CALLHELDREASONS": null,
     "CODEAFTERINITACCESS": null,
     "COMPONENTS": null,
@@ -40754,7 +43846,33 @@
       "PLAN_TYPE_ID": 122
      }
     ],
-    "ACTION_OFFICERS": null,
+    "ACTION_OFFICERS": [
+  {
+   "EMAIL": "lesterT@example.gov",
+   "FIRST_NAME": "Lester",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3740,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "SuperT@example.gov",
+   "FIRST_NAME": "Super",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3741,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  },{
+   "EMAIL": "jimmyT@example.gov",
+   "FIRST_NAME": "Jimmy",
+   "INITIALS": null,
+   "LAST_NAME": "Tester",
+   "OFFICER_ID": 3742,
+   "POSITION_ID": 538,
+   "TELEPHONE": "(410) 555-5445"
+  }
+ ],
     "CALLHELDREASONS": null,
     "CODEAFTERINITACCESS": null,
     "COMPONENTS": null,

--- a/services/ui-src/src/libs/detailLib.ts
+++ b/services/ui-src/src/libs/detailLib.ts
@@ -16,6 +16,7 @@ export type OneMACDetail = {
   actionsByStatus: Record<string, Workflow.PACKAGE_ACTION[]>;
   detailHeader?: string;
   detailSection: AttributeDetail[];
+  showReviewTeam: boolean;
   allowWaiverExtension: boolean;
   attachmentsHeading: string;
 } & Partial<PackageType>;
@@ -131,6 +132,7 @@ export const defaultDetail: OneMACDetail = {
   actionsByStatus: Workflow.defaultActionsByStatus,
   show90thDayInfo: false,
   showEffectiveDate: false,
+  showReviewTeam: true,
   detailHeader: "Package",
   allowWaiverExtension: false,
   detailSection: [...defaultDetailSectionItems],

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -162,12 +162,14 @@ export const DetailSection = ({
                 </Review>
               )
           )}
-          <ExpandableList
-            heading="Review Team (SRT)"
-            list={detail.reviewTeam}
-            numToShow={NUM_REVIEWERS_TO_SHOW}
-            className="review-team"
-          ></ExpandableList>
+          {pageConfig.showReviewTeam && (
+            <ExpandableList
+              heading="Review Team (SRT)"
+              list={detail.reviewTeam}
+              numToShow={NUM_REVIEWERS_TO_SHOW}
+              className="review-team"
+            ></ExpandableList>
+          )}
         </section>
         <section className="detail-section ds-u-margin-bottom--7">
           {detail.attachments?.length > 0 ? (

--- a/services/ui-src/src/page/temporary-extension/TemporaryExtensionDetail.tsx
+++ b/services/ui-src/src/page/temporary-extension/TemporaryExtensionDetail.tsx
@@ -32,6 +32,7 @@ export const waiverTemporaryExtensionDetail: OneMACDetail = {
   detailHeader: "Temporary Extension Request",
   actionsByStatus: Workflow.waiverExtensionActionsByStatus,
   show90thDayInfo: false,
+  showReviewTeam: false,
   detailSection: [
     componentIdDetail,
     parentIdDetail,


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24181
Endpoint: See github-actions bot comment

### Details
So.... chickened out on fixing this bug before 23578 got demo'd because it *is* a bit of code change.  Though... turns out to be a lot less change than I thought, since we already had the concept of "showProposedDate" to follow...

### Changes
- put the ReviewTeam component behind a flag, showReviewTeam
- Added the showReviewTeam flag to the default configs -- default is true
- set value to false for the Temporary Extension Detail configs

### Test Plan
1. Login as a CMS user
2. Verify that the Review Team is not displayed for Temporary Extension Details
3. Verify that the Review Team *is* displayed for all other component types
