### PR TITLE
align alert bar dimensions to be same as header

### DIFF
--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -346,10 +346,17 @@ ul {
 
 .alert-bar:not(:empty) {
   padding-top: 2rem;
-  padding-left: 14rem;
-  padding-right: 14rem;
+  padding-left: 7.2rem;
+  padding-right: 7.2rem;
   padding-bottom: 2rem;
 }
+
+.ds-c-alert {
+  @extend .ds-u-margin-left--auto;
+  @extend .ds-u-margin-right--auto;
+  @include max-width-ultra-wide;
+}
+
 .alert-bar button {
   position: absolute;
   background: inherit;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-23918
Endpoint: See github-actions bot comment

### Details

Update format of alert bar to have max size same as header

### Changes

- Css updates to alert-bar and ds-c-alert classes


### Test Plan

1. login as state submitter
2. submit any new package
3. verify alert bar sizing
