### PR TITLE
oy2-235228 - fix margins to be same for all content and headers under 1024px wide

### DIFF
--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -180,8 +180,6 @@ p.field-hint {
 }
 .app-bar {
   @extend .ds-l-row;
-  padding-left: 7.2rem;
-  padding-right: 7.2rem;
   @extend .ds-u-padding-top--1;
   @extend .ds-u-padding-bottom--1;
   @extend .ds-u-margin-left--0;
@@ -346,10 +344,17 @@ ul {
 
 .alert-bar:not(:empty) {
   padding-top: 2rem;
-  padding-left: 14rem;
-  padding-right: 14rem;
   padding-bottom: 2rem;
+  @include max-width-ultra-wide();
+  @extend .ds-u-margin-left--auto;
+  @extend .ds-u-margin-right--auto;
+
+  @media only screen and (max-width: 1024px) {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
 }
+
 .alert-bar button {
   position: absolute;
   background: inherit;
@@ -591,9 +596,11 @@ input[type="file"] {
 }
 
 .onemac-form {
-  @extend .app-bar;
   @extend .ds-u-padding-top--5;
   @extend .ds-u-justify-content--center;
+  margin-left: 1rem;
+  margin-right: 1rem;
+  @extend .ds-l-row;
   flex-direction: column;
   align-items: center;
 
@@ -1335,10 +1342,11 @@ article.form-container {
   text-decoration-skip-ink: none;
 }
 .usa-bar {
-  @extend .app-bar;
   background-color: $color-gray-lightest;
   font-size: 14px;
   min-height: 20px;
+  margin-left: 1rem;
+  margin-right: 1rem;
 
   img {
     height: 20px;
@@ -1500,17 +1508,16 @@ article.form-container {
 .footer-bottom-container {
   @extend .ds-u-display--flex;
   @extend .ds-u-justify-content--around;
-  padding-left: 7.2rem;
-  padding-right: 7.2rem;
 
   .header-wrapper,
   .footer-wrapper {
+    margin-left: 1rem;
+    margin-right: 1rem;
     @include max-width-ultra-wide;
     @extend .ds-u-display--flex;
     @extend .ds-u-align-items--center;
     @extend .ds-u-justify-content--between;
-    gap: 1rem;
-    width: 100%;
+    width: 100vw;
   }
 
   @media only screen and (max-width: $width-lg) {
@@ -1584,8 +1591,6 @@ article.form-container {
   @extend .ds-u-display--flex;
   @extend .ds-u-justify-content--around;
   background-color: #f0f0f0;
-  padding-left: 7.2rem;
-  padding-right: 7.2rem;
 
   .ds-c-usa-banner {
     @include max-width-ultra-wide;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-23528
Endpoint: See github-actions bot comment

### Details

Bandaids and duct tape to make css behave without restructuring......i think i used bubblegum too

### Changes

- CSS changes only

### Test Plan

1. Login as any user
2. Navigate to package dashboard and observe behavior of all page elements margins for various screen dimensions
3. Navigate to all other page types to verify header/content behave as expected (package submission, package details, user profile, etc)
