### PR TITLE
[DO NOT MERGE] - feat(iam): Changes to support bigmac IAM auth 

### DIFF
--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -48,7 +48,7 @@ provider:
   runtime: nodejs14.x
   region: us-east-1
   stage: dev
-  disableRollback: false
+  disableRollback: true
 
 
 

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -166,7 +166,7 @@ resources:
               - |
                   export CONNECT_REST_HOST_NAME=`curl $ECS_CONTAINER_METADATA_URI_V4 | sed -e 's/.*IPv4Addresses":\["\(.*\)"\],"AttachmentIndex.*/\1/'` &&
                   export CONNECT_REST_ADVERTISED_HOST_NAME=$CONNECT_REST_HOST_NAME &&
-                  curl -k -SL -o /usr/share/java/cp-base-new/aws-msk-iam-auth-1.1.3-all.jar "https://github.com/aws/aws-msk-iam-auth/releases/download/v1.1.3/aws-msk-iam-auth-1.1.3-all.jar" &&
+                  curl -k -SL -o /etc/kafka-connect/jars/aws-msk-iam-auth-1.1.3-all.jar "https://github.com/aws/aws-msk-iam-auth/releases/download/v1.1.3/aws-msk-iam-auth-1.1.3-all.jar" &&
                   curl -k -SL -o /etc/kafka-connect/jars/kafka-connect-lambda-1.2.2.jar "https://github.com/Nordstrom/kafka-connect-lambda/releases/download/v1.2.2/kafka-connect-lambda-1.2.2.jar" &&
                   /etc/confluent/docker/run
             Environment:
@@ -196,7 +196,7 @@ resources:
               - Name: CONNECT_PLUGIN_PATH
                 Value: /usr/share/java,/etc/kafka-connect/jars
               - Name: CLASSPATH
-                Value: /etc/kafka-connect/jars/*:/usr/share/java/cp-base-new/aws-msk-iam-auth-1.1.3-all.jar
+                Value: /etc/kafka-connect/jars/kafka*:/etc/kafka-connect/jars/aws-msk-iam-auth-1.1.3-all.jar
               - Name: CONNECT_SECURITY_PROTOCOL
                 Value: SASL_SSL
               - Name: CONNECT_SASL_MECHANISM

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -48,6 +48,13 @@ provider:
   runtime: nodejs14.x
   region: us-east-1
   stage: dev
+  disableRollback: true
+
+
+
+
+
+
 
 functions:
   seaToolEvent:

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -157,19 +157,27 @@ resources:
       Properties:
         ContainerDefinitions:
           - Name: ${self:service}-${self:custom.stage}-worker
-            Image: 'confluentinc/cp-kafka-connect:5.2.4'
+            Image: 'confluentinc/cp-kafka-connect:6.0.9'
             Memory: 4096
             Cpu: 2048
+            User: "root"
             Command:
               - bash
               - "-c"
               - |
-                  mkdir -p /usr/share/java/cp-base-new
-                  export CONNECT_REST_HOST_NAME=`curl $ECS_CONTAINER_METADATA_URI_V4 | sed -e 's/.*IPv4Addresses":\["\(.*\)"\],"AttachmentIndex.*/\1/'` &&
-                  export CONNECT_REST_ADVERTISED_HOST_NAME=$CONNECT_REST_HOST_NAME &&
+                export ENI_IP=`curl $ECS_CONTAINER_METADATA_URI_V4 | sed -e 's/.*IPv4Addresses":\["\(.*\)"\],"AttachmentIndex.*/\1/'` &&
+                echo "$ENI_IP localhost" > /etc/hosts &&
+                echo "export ENI_IP=$ENI_IP" >> /home/appuser/.bashrc
+                runuser -p appuser -c '''
+                  export HOME=/home/appuser &&
+                  source /home/appuser/.bashrc
+                  export CONNECT_REST_HOST_NAME=$ENI_IP &&
+                  export CONNECT_REST_ADVERTISED_HOST_NAME=$ENI_IP &&
                   curl -k -SL -o /usr/share/java/cp-base-new/aws-msk-iam-auth-1.1.3-all.jar "https://github.com/aws/aws-msk-iam-auth/releases/download/v1.1.3/aws-msk-iam-auth-1.1.3-all.jar" &&
                   curl -k -SL -o /etc/kafka-connect/jars/kafka-connect-lambda-1.2.2.jar "https://github.com/Nordstrom/kafka-connect-lambda/releases/download/v1.2.2/kafka-connect-lambda-1.2.2.jar" &&
+                  chmod +x /etc/kafka-connect/jaras/kafka-connect-lambda-1.2.2.jar
                   /etc/confluent/docker/run
+                '''
             Environment:
               - Name: CONNECT_BOOTSTRAP_SERVERS
                 Value: >-
@@ -195,7 +203,7 @@ resources:
               - Name: CONNECT_INTERNAL_VALUE_CONVERTER
                 Value: org.apache.kafka.connect.json.JsonConverter
               - Name: CONNECT_PLUGIN_PATH
-                Value: /usr/share/java,/etc/kafka-connect/jars,/usr/local/share/kafka/plugins
+                Value: /usr/share/java,/usr/local/share/kafka/plugins
               - Name: CLASSPATH
                 Value: /etc/kafka-connect/jars/*:/usr/share/java/cp-base-new/aws-msk-iam-auth-1.1.3-all.jar
               - Name: CONNECT_SECURITY_PROTOCOL

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -48,7 +48,7 @@ provider:
   runtime: nodejs14.x
   region: us-east-1
   stage: dev
-  disableRollback: true
+  #disableRollback: true
 
 
 

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -164,6 +164,8 @@ resources:
               - bash
               - "-c"
               - |
+                  which java
+                  ls /usr/share/java
                   export CONNECT_REST_HOST_NAME=`curl $ECS_CONTAINER_METADATA_URI_V4 | sed -e 's/.*IPv4Addresses":\["\(.*\)"\],"AttachmentIndex.*/\1/'` &&
                   export CONNECT_REST_ADVERTISED_HOST_NAME=$CONNECT_REST_HOST_NAME &&
                   curl -k -SL -o /etc/kafka-connect/jars/aws-msk-iam-auth-1.1.3-all.jar "https://github.com/aws/aws-msk-iam-auth/releases/download/v1.1.3/aws-msk-iam-auth-1.1.3-all.jar" &&

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -164,11 +164,10 @@ resources:
               - bash
               - "-c"
               - |
-                  which java
-                  ls /usr/share/java
+                  mkdir -p /usr/share/java/cp-base-new
                   export CONNECT_REST_HOST_NAME=`curl $ECS_CONTAINER_METADATA_URI_V4 | sed -e 's/.*IPv4Addresses":\["\(.*\)"\],"AttachmentIndex.*/\1/'` &&
                   export CONNECT_REST_ADVERTISED_HOST_NAME=$CONNECT_REST_HOST_NAME &&
-                  curl -k -SL -o /etc/kafka-connect/jars/aws-msk-iam-auth-1.1.3-all.jar "https://github.com/aws/aws-msk-iam-auth/releases/download/v1.1.3/aws-msk-iam-auth-1.1.3-all.jar" &&
+                  curl -k -SL -o /usr/share/java/cp-base-new/aws-msk-iam-auth-1.1.3-all.jar "https://github.com/aws/aws-msk-iam-auth/releases/download/v1.1.3/aws-msk-iam-auth-1.1.3-all.jar" &&
                   curl -k -SL -o /etc/kafka-connect/jars/kafka-connect-lambda-1.2.2.jar "https://github.com/Nordstrom/kafka-connect-lambda/releases/download/v1.2.2/kafka-connect-lambda-1.2.2.jar" &&
                   /etc/confluent/docker/run
             Environment:
@@ -196,9 +195,9 @@ resources:
               - Name: CONNECT_INTERNAL_VALUE_CONVERTER
                 Value: org.apache.kafka.connect.json.JsonConverter
               - Name: CONNECT_PLUGIN_PATH
-                Value: /usr/share/java,/etc/kafka-connect/jars
+                Value: /usr/share/java,/etc/kafka-connect/jars,/usr/local/share/kafka/plugins
               - Name: CLASSPATH
-                Value: /etc/kafka-connect/jars/kafka*:/etc/kafka-connect/jars/aws-msk-iam-auth-1.1.3-all.jar
+                Value: /etc/kafka-connect/jars/*:/usr/share/java/cp-base-new/aws-msk-iam-auth-1.1.3-all.jar
               - Name: CONNECT_SECURITY_PROTOCOL
                 Value: SASL_SSL
               - Name: CONNECT_SASL_MECHANISM

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -48,7 +48,7 @@ provider:
   runtime: nodejs14.x
   region: us-east-1
   stage: dev
-  #disableRollback: true
+  disableRollback: false
 
 
 

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -72,7 +72,7 @@ functions:
         - KafkaConnectWorkerRole
         - Arn
       sessionName: ${self:custom.stage}-sink-role
-      topics: aws.ksqldb.seatool.agg.StatePlan_Medicaid_SPA,aws.ksqldb.seatool.agg.StatePlan_CHIP_SPA,aws.ksqldb.seatool.agg.StatePlan_1915b_waivers,aws.ksqldb.seatool.agg.StatePlan_1915c_waivers,aws.ksqldb.seatool.agg.StatePlan_1915c_Indep_Plus,aws.ksqldb.seatool.agg.StatePlan_1115,aws.ksqldb.seatool.agg.StatePlan_UPL
+      topics: --seatool--iam--aws.ksqldb.seatool.agg.StatePlan_Medicaid_SPA,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_CHIP_SPA,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1915b_waivers,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1915c_waivers,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1915c_Indep_Plus,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1115,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_UPL
       sinkPrefix: onemac-${self:custom.stage}-v4
     maximumRetryAttempts: 2
     timeout: 120

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -21,6 +21,7 @@ custom:
   bootstrapBrokerStringTls: ${ssm:/configuration/${self:custom.stage}/bigmac/bootstrapBrokerStringTls, ssm:/configuration/default/bigmac/bootstrapBrokerStringTls}
   vpcId: ${ssm:/configuration/${self:custom.stage}/vpc/id, ssm:/configuration/default/vpc/id}
   connectGroup: mgmt.connect.${self:service}-${self:custom.stage}
+  bigmacRoleArn: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/bigmacRoleArn, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/bigmacRoleArn}
   dataSubnets:
     - ${ssm:/configuration/${self:custom.stage}/vpc/subnets/data/a/id, ssm:/configuration/default/vpc/subnets/data/a/id}
     - ${ssm:/configuration/${self:custom.stage}/vpc/subnets/data/b/id, ssm:/configuration/default/vpc/subnets/data/b/id}
@@ -63,6 +64,7 @@ functions:
     environment:
       cluster: !Ref KafkaConnectCluster
       bootstrapBrokerStringTls: ${self:custom.bootstrapBrokerStringTls}
+      bigmacRoleArn: ${self:custom.bigmacRoleArn}
       functionArn: !GetAtt
         - SeaToolEventLambdaFunction
         - Arn
@@ -138,6 +140,11 @@ resources:
                 Resource: !GetAtt
                   - SeaToolEventLambdaFunction
                   - Arn
+              - Effect: "Allow"
+                Action:
+                  - sts:AssumeRole
+                Resource:
+                  - ${self:custom.bigmacRoleArn}
     KafkaConnectWorkerTaskDefinition:
       Type: 'AWS::ECS::TaskDefinition'
       Properties:
@@ -152,6 +159,7 @@ resources:
               - |
                   export CONNECT_REST_HOST_NAME=`curl $ECS_CONTAINER_METADATA_URI_V4 | sed -e 's/.*IPv4Addresses":\["\(.*\)"\],"AttachmentIndex.*/\1/'` &&
                   export CONNECT_REST_ADVERTISED_HOST_NAME=$CONNECT_REST_HOST_NAME &&
+                  curl -k -SL -o /usr/share/java/cp-base-new/aws-msk-iam-auth-1.1.3-all.jar "https://github.com/aws/aws-msk-iam-auth/releases/download/v1.1.3/aws-msk-iam-auth-1.1.3-all.jar" &&
                   curl -k -SL -o /etc/kafka-connect/jars/kafka-connect-lambda-1.2.2.jar "https://github.com/Nordstrom/kafka-connect-lambda/releases/download/v1.2.2/kafka-connect-lambda-1.2.2.jar" &&
                   /etc/confluent/docker/run
             Environment:
@@ -180,20 +188,40 @@ resources:
                 Value: org.apache.kafka.connect.json.JsonConverter
               - Name: CONNECT_PLUGIN_PATH
                 Value: /usr/share/java,/etc/kafka-connect/jars
+              - Name: CLASSPATH
+                Value: /etc/kafka-connect/jars/*:/usr/share/java/cp-base-new/aws-msk-iam-auth-1.1.3-all.jar
               - Name: CONNECT_SECURITY_PROTOCOL
-                Value: SSL
+                Value: SASL_SSL
+              - Name: CONNECT_SASL_MECHANISM
+                Value: AWS_MSK_IAM
+              - Name: CONNECT_SASL_JAAS_CONFIG
+                Value: software.amazon.msk.auth.iam.IAMLoginModule required awsRoleArn="${self:custom.bigmacRoleArn}";
+              - Name: CONNECT_SASL_CLIENT_CALLBACK_HANDLER_CLASS
+                Value: software.amazon.msk.auth.iam.IAMClientCallbackHandler
               # Producer/Consumer configs below
               # Thank you to https://github.com/confluentinc/kafka-connect-jdbc/issues/161
               - Name: CONNECT_PRODUCER_BOOTSTRAP_SERVERS
                 Value: >-
                   ${self:custom.bootstrapBrokerStringTls}
               - Name: CONNECT_PRODUCER_SECURITY_PROTOCOL
-                Value: SSL
+                Value: SASL_SSL
+              - Name: CONNECT_PRODUCER_SASL_MECHANISM
+                Value: AWS_MSK_IAM
+              - Name: CONNECT_PRODUCER_SASL_JAAS_CONFIG
+                Value: software.amazon.msk.auth.iam.IAMLoginModule required awsRoleArn="${self:custom.bigmacRoleArn}";
+              - Name: CONNECT_PRODUCER_SASL_CLIENT_CALLBACK_HANDLER_CLASS
+                Value: software.amazon.msk.auth.iam.IAMClientCallbackHandle
               - Name: CONNECT_CONSUMER_BOOTSTRAP_SERVERS
                 Value: >-
                   ${self:custom.bootstrapBrokerStringTls}
               - Name: CONNECT_CONSUMER_SECURITY_PROTOCOL
-                Value: SSL
+                Value: SASL_SSL
+              - Name: CONNECT_CONSUMER_SASL_MECHANISM
+                Value: AWS_MSK_IAM
+              - Name: CONNECT_CONSUMER_SASL_JAAS_CONFIG
+                Value: software.amazon.msk.auth.iam.IAMLoginModule required awsRoleArn="${self:custom.bigmacRoleArn}";
+              - Name: CONNECT_CONSUMER_SASL_CLIENT_CALLBACK_HANDLER_CLASS
+                Value: software.amazon.msk.auth.iam.IAMClientCallbackHandler     
             LogConfiguration:
               LogDriver: awslogs
               Options:
@@ -289,7 +317,6 @@ resources:
                 - ecs:ListTasks
                 - ecs:DescribeTasks
                 Resource: '*'
-
     LambdaSecurityGroup:
       Type: AWS::EC2::SecurityGroup
       Properties:

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -48,13 +48,6 @@ provider:
   runtime: nodejs14.x
   region: us-east-1
   stage: dev
-  disableRollback: true
-
-
-
-
-
-
 
 functions:
   seaToolEvent:

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -21,7 +21,7 @@ custom:
   bootstrapBrokerStringTls: ${ssm:/configuration/${self:custom.stage}/bigmac/bootstrapBrokerStringTls, ssm:/configuration/default/bigmac/bootstrapBrokerStringTls}
   vpcId: ${ssm:/configuration/${self:custom.stage}/vpc/id, ssm:/configuration/default/vpc/id}
   connectGroup: mgmt.connect.${self:service}-${self:custom.stage}
-  bigmacRoleArn: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/bigmacRoleArn, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/bigmacRoleArn}
+  bigmacRoleArn: ${ssm:/aws/reference/secretsmanager/onemac/${sls:stage}/bigmacRoleArn, ssm:/aws/reference/secretsmanager/onemac/default/bigmacRoleArn}
   dataSubnets:
     - ${ssm:/configuration/${self:custom.stage}/vpc/subnets/data/a/id, ssm:/configuration/default/vpc/subnets/data/a/id}
     - ${ssm:/configuration/${self:custom.stage}/vpc/subnets/data/b/id, ssm:/configuration/default/vpc/subnets/data/b/id}


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-XXXX
Endpoint: See github-actions bot comment

### Details

 This changeset represents what's needed to preserve all project functionality when Bigmac IAM Auth is enabled.

### Changes

The connector ECS task was modified to accomodate IAM. An msk iam auth jar is installed as part of the bootstrapping process. The environment variables passed to the container are also expanded and modified, with the appropriate config for IAM auth. In particular, in these env variables is where we say "assume this role".

### Implementation Notes
NB: We added --seatool--iam-- as a prfix to the topics. Please remove the prefix from all topics before merging.

 --seatool--iam--aws.ksqldb.seatool.agg.StatePlan_Medicaid_SPA,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_CHIP_SPA,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1915b_waivers,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1915c_waivers,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1915c_Indep_Plus,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1115,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_UPL

