### PR TITLE
Update target for all FAQ links

### DIFF
--- a/services/common/index.d.ts
+++ b/services/common/index.d.ts
@@ -1,6 +1,11 @@
 export const RESPONSE_CODE: Record<string, string>;
 export const FORM_SUCCESS_RESPONSE_CODES: string[];
-export { ROUTES, ONEMAC_ROUTES, TYPE_TO_DETAIL_ROUTE } from "./routes.js";
+export {
+  ROUTES,
+  ONEMAC_ROUTES,
+  TYPE_TO_DETAIL_ROUTE,
+  FAQ_TARGET,
+} from "./routes.js";
 
 export const approvedBlueWarningMessage: string;
 

--- a/services/common/index.js
+++ b/services/common/index.js
@@ -41,7 +41,12 @@ export { chipSPARAIResponse } from "./type/chipSPARAIResponse.js";
 export { chipSPAWithdraw } from "./type/chipSPAWithdraw.js";
 
 import { ROUTES, ONEMAC_ROUTES } from "./routes.js";
-export { ROUTES, ONEMAC_ROUTES, TYPE_TO_DETAIL_ROUTE } from "./routes.js";
+export {
+  ROUTES,
+  ONEMAC_ROUTES,
+  TYPE_TO_DETAIL_ROUTE,
+  FAQ_TARGET,
+} from "./routes.js";
 
 export const dynamoConfig = process.env.IS_OFFLINE
   ? {

--- a/services/common/routes.js
+++ b/services/common/routes.js
@@ -5,6 +5,7 @@
 
 import { ONEMAC_TYPE } from "./workflow.js";
 
+export const FAQ_TARGET = "tab-faq";
 export const ROUTES = {
   DETAIL: "/detail",
   USER_MANAGEMENT: "/usermanagement",

--- a/services/ui-src/src/components/ComponentId.tsx
+++ b/services/ui-src/src/components/ComponentId.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "@material-ui/core";
-import { FieldHint } from "cmscommonlib";
+import { FAQ_TARGET, FieldHint } from "cmscommonlib";
 import { Review } from "@cmsgov/design-system";
 import { Message } from "../libs/formLib";
 
@@ -36,7 +36,7 @@ const ComponentId: React.FC<{
             </label>
             {idFAQLink && (
               <div className="label-rcol">
-                <Link target="new" href={idFAQLink}>
+                <Link target={FAQ_TARGET} href={idFAQLink}>
                   What is my {idLabel}?
                 </Link>
               </div>

--- a/services/ui-src/src/components/Header.tsx
+++ b/services/ui-src/src/components/Header.tsx
@@ -212,7 +212,6 @@ export function Header() {
         href={ROUTES.FAQ}
         className={getActiveClass(currentRoute, RouteList.FAQ_TOP)}
         target={FAQ_TARGET}
-        rel="noreferrer noopener"
       >
         FAQ
       </a>

--- a/services/ui-src/src/components/Header.tsx
+++ b/services/ui-src/src/components/Header.tsx
@@ -13,6 +13,7 @@ import {
   USER_ROLE,
   getUserRoleObj,
   inFlightRoleRequestForUser,
+  FAQ_TARGET,
 } from "cmscommonlib";
 import { getRegisterUrl, getSignInUrl, logout } from "../libs/logoutLib";
 import { getCurrentRoute } from "../utils/routeUtils";
@@ -210,7 +211,7 @@ export function Header() {
         id="faqLink"
         href={ROUTES.FAQ}
         className={getActiveClass(currentRoute, RouteList.FAQ_TOP)}
-        target="_blank"
+        target={FAQ_TARGET}
         rel="noreferrer noopener"
       >
         FAQ

--- a/services/ui-src/src/components/HomeFooter.js
+++ b/services/ui-src/src/components/HomeFooter.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { ROUTES } from "cmscommonlib";
+import { FAQ_TARGET, ROUTES } from "cmscommonlib";
 
 function HomeFooter() {
   return (
@@ -12,7 +12,7 @@ function HomeFooter() {
           </div>
           <div className="ds-l-col--3 ds-u-margin-left--auto">
             <a
-              target="new"
+              target={FAQ_TARGET}
               href={ROUTES.FAQ_TOP}
               className="ds-c-button ds-c-button--primary ds-u-text-decoration--none"
             >

--- a/services/ui-src/src/components/TriageExternalLandingPage.tsx
+++ b/services/ui-src/src/components/TriageExternalLandingPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button } from "@cmsgov/design-system";
 import PageTitleBar from "./PageTitleBar";
-import { ROUTES } from "cmscommonlib";
+import { FAQ_TARGET, ROUTES } from "cmscommonlib";
 import { Link } from "@material-ui/core";
 
 export enum ExternalSystem {
@@ -24,7 +24,7 @@ const FAQHelperText = () => (
   <span className="landing-description">
     <i>
       For additional information on where to submit, refer to the{" "}
-      <Link target="new" href={ROUTES.FAQ_SYSTEM}>
+      <Link target={FAQ_TARGET} href={ROUTES.FAQ_SYSTEM}>
         Crosswalk from Paper-based State Plan to MACPro and MMDL
       </Link>{" "}
       document in our FAQ section.

--- a/services/ui-src/src/libs/formLib.tsx
+++ b/services/ui-src/src/libs/formLib.tsx
@@ -5,6 +5,7 @@ import {
   FileUploadProps,
   ONEMAC_ROUTES,
   ROUTES,
+  FAQ_TARGET,
 } from "cmscommonlib";
 import config from "../utils/config";
 import { Link } from "react-router-dom";
@@ -55,7 +56,7 @@ export const DefaultFileTypesInfo = () => (
       .xls, .xlsx, and a few others.
     </b>{" "}
     See the full list on the{" "}
-    <Link to={ROUTES.FAQ_ACCEPTED_FILE_TYPES} target="_blank">
+    <Link to={ROUTES.FAQ_ACCEPTED_FILE_TYPES} target={FAQ_TARGET}>
       FAQ Page
     </Link>
     .
@@ -67,7 +68,7 @@ export const DefaultFileSizeInfo = ({ route }: { route: string }) => (
     Maximum file size of {config.MAX_ATTACHMENT_SIZE_MB} MB per attachment.{" "}
     <b>You can add multiple files per attachment type.</b> Read the description
     for each of the attachment types on the{" "}
-    <Link to={route} target="_blank">
+    <Link to={route} target={FAQ_TARGET}>
       FAQ Page
     </Link>
     .

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -12,6 +12,7 @@ import { Input } from "rsuite";
 import { TextField, Button, Review } from "@cmsgov/design-system";
 
 import {
+  FAQ_TARGET,
   FORM_SUCCESS_RESPONSE_CODES,
   RESPONSE_CODE,
   ROUTES,
@@ -568,7 +569,7 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
         <div className="faq-container">
           <span>Do you have questions or need support?</span>
           <a
-            target="new"
+            target={FAQ_TARGET}
             href={ROUTES.FAQ_TOP}
             className="ds-c-button ds-c-button--primary ds-u-text-decoration--none"
           >

--- a/services/ui-src/src/page/medicaid-spa/MedicaidSpaForm.tsx
+++ b/services/ui-src/src/page/medicaid-spa/MedicaidSpaForm.tsx
@@ -6,7 +6,7 @@ import {
   OneMACFormConfig,
   RequiredAttachmentSpan,
 } from "../../libs/formLib";
-import { ROUTES, ONEMAC_ROUTES, medicaidSPA } from "cmscommonlib";
+import { ROUTES, ONEMAC_ROUTES, medicaidSPA, FAQ_TARGET } from "cmscommonlib";
 import config from "../../utils/config";
 import { Link } from "react-router-dom";
 
@@ -33,7 +33,7 @@ export const medicaidSpaFormInfo: OneMACFormConfig = {
         Maximum file size of {config.MAX_ATTACHMENT_SIZE_MB} MB per attachment.
         You can add multiple files per attachment type, except for the CMS Form
         179. Read the description for each of the attachment types on the{" "}
-        <Link to={ROUTES.FAQ_ATTACHMENTS_MED_SPA} target="_blank">
+        <Link to={ROUTES.FAQ_ATTACHMENTS_MED_SPA} target={FAQ_TARGET}>
           FAQ Page
         </Link>
         .


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24192
Endpoint: See github-actions bot comment

### Details

This PR unifies all FAQ links so they open in `target="tab-faq"` by way of a new exported variable in `routes.js`, `FAQ_TARGET`. 

### Changes

- New constant in `common/routes.js`
- Change value for `target` on FAQ links

### Implementation Notes

N/A

### Test Plan

1. Ensure FAQ nav link opens in new tab
2. LEAVE THAT TAB OPEN! 😄 
3. Navigate back to the original tab.
4. Ensure FAQ link in footer opens in the existing FAQ tab.
5. Repeat steps 3-4 for FAQ links from a Form (these are procedurally created, so one form should be fine for testing)
6. Repeat steps 3-4 for FAQ inks from triage landing pages (i.e. the pages that link to MMDL and MacPRO)
