### PR TITLE
OY2 24353: Submit TEs on 1915c waivers - missed topic

### DIFF
--- a/services/one-stream/handleOneStream.js
+++ b/services/one-stream/handleOneStream.js
@@ -80,10 +80,12 @@ export const main = async (eventBatch) => {
                   packageToBuild.type = Workflow.ONEMAC_TYPE.WAIVER_INITIAL;
                 break;
               case "1915c_waivers":
-                console.log("actionType is: ", actionType);
                 if (actionType === "Amend")
                   packageToBuild.type = Workflow.ONEMAC_TYPE.WAIVER_APP_K;
-                else console.log("newEventData is: ", newEventData);
+                else if (actionType === "Renew")
+                  packageToBuild.type = Workflow.ONEMAC_TYPE.WAIVER_RENEWAL;
+                else if (actionType === "New")
+                  packageToBuild.type = Workflow.ONEMAC_TYPE.WAIVER_INITIAL;
                 break;
               default:
                 break;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24353
Endpoint: See github-actions bot comment

### Details
The recent refactor to perform validation on parent packages of TEs neglected to include the 1915c waiver topic.

### Changes
- handle 1915c waivers the same as SEA Tool-only 1915b waivers, as in, they get a package, but no GSI1, so they are searchable, but not shown on the dashboard.

### Test Plan
1. Verify that 1915c packages are built "correctly" (as far as we know, they are the same as 1915b waivers)
2. Verify that 1915c waivers do not show on dashboard
3. Verify that you can submit a TE on a valid 1915c waiver (Approved Initial or Renewal).
Example IDs: MD-0023.R06.00, MD-0339.R02.00
