### PR TITLE
Remove nowrap css rule for title bar text

### DIFF
--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -205,7 +205,6 @@ p.field-hint {
     @extend .ds-u-flex-direction--row;
     @extend .ds-u-align-items--center;
     flex-direction: row;
-    white-space: nowrap;
   }
 
   &.title-bar-dark-theme {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-XXXX
Endpoint: See github-actions bot comment

### Details

This PR performs some CSS acupuncture to cure a non-wrapping long page title

BEFORE
<img width="700" alt="Screen Shot 2023-06-12 at 1 30 55 PM" src="https://github.com/Enterprise-CMCS/macpro-onemac/assets/4022304/b1f5e6fd-d70e-453c-bd97-a868544411ec">

AFTER
<img width="700" alt="Screen Shot 2023-06-12 at 1 31 31 PM" src="https://github.com/Enterprise-CMCS/macpro-onemac/assets/4022304/d5009b65-7aaf-4e7f-b5bc-a5fd2645f8b9">


### Changes

- Remove `white-space: nowrap` from `.page-title-bar > .title-bar-left-content`

### Implementation Notes

- I couldn't find any indication of the need for `nowrap`, but **please let me know if there is one, and I'll adjust the method taken to fix this bug!** 😄 

### Test Plan

1. Follow the bug recreation steps given in the ticket linked
2. Ensure by resizing you are able to see titles wrap accordingly, removing any prior overflow-x scrolling
