### PR TITLE
OY2 24305: Automated Deletion of ZZ-state Submissions from PROD

### DIFF
--- a/services/admin/handlers/deleteZZItems.js
+++ b/services/admin/handlers/deleteZZItems.js
@@ -1,0 +1,62 @@
+import AWS from "aws-sdk";
+
+const dynamoDb = new AWS.DynamoDB.DocumentClient(
+  process.env.IS_OFFLINE
+    ? {
+        endpoint: "http://localhost:8000",
+      }
+    : {}
+);
+
+/**
+ * Reset test Data
+ */
+
+export const main = async (event) => {
+  console.log("deleteZZItems event: ", event);
+
+  const deleteItems = [];
+  let results;
+
+  const dParams = {
+    TableName: process.env.oneMacTableName,
+    ProjectionExpression: "pk,sk",
+    FilterExpression: "begins_with(pk, :zzstate)",
+    ExclusiveStartKey: null,
+    ExpressionAttributeValues: {
+      ":zzstate": "ZZ",
+    },
+  };
+
+  do {
+    try {
+      results = await dynamoDb.scan(dParams).promise();
+      for (const item of results.Items) {
+        deleteItems.push({
+          TableName: process.env.oneMacTableName,
+          Key: {
+            pk: item.pk,
+            sk: item.sk,
+          },
+        });
+      }
+    } catch (e) {
+      console.log("query error: ", e.message);
+    }
+    dParams.ExclusiveStartKey = results.LastEvaluatedKey;
+  } while (dParams.ExclusiveStartKey);
+
+  await Promise.all(
+    deleteItems.map(async (deleteParams) => {
+      try {
+        console.log(`Delete Params are ${JSON.stringify(deleteParams)}`);
+
+        await dynamoDb.delete(deleteParams).promise();
+      } catch (e) {
+        console.log("delete error: ", e.message);
+      }
+    })
+  );
+  console.log("lambda thinks " + deleteItems.length + " Items are deleted");
+  return "Done";
+};

--- a/services/admin/serverless.yml
+++ b/services/admin/serverless.yml
@@ -70,3 +70,10 @@ functions:
   updatePackageId:
     handler: ./handlers/updatePackageId.main
     timeout: 180
+
+  deleteZZItems:
+    handler: ./handlers/deleteZZItems.main
+    events:
+      - schedule:
+          rate: rate(6 hours)
+    timeout: 180


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24305
Endpoint: See github-actions bot comment

### Details
We use the ZZ state in PROD as a test-territory for verification of PROD deployments and email sending.  After the tests are performed, we should clean out the ZZ-state entries.  If we schedule this appropriately, the cleanup should happen after all testing is done.

### Changes
- Add an admin service lambda to delete all events that begin with ZZ
- Schedule the service to remove ZZ data every 6 hours.

### Test Plan
1. Login as statesubmitter@nightwatch.test (or another submitting user, but make sure to grant access to ZZ state submissions)
2. Submit a package for ZZ state - make note of the package ID used.
3. Verify the ZZ state package is on the dashboard, etc.
4. Wait at most 6 hours.
5. Verify the ZZ state package is no longer on the dashboard.
6. Verify that the same packageID can be used again.
