### PR TITLE
OY2 24262: Splitting packages can mean NOSOs that pull attachments from an OSO

### DIFF
--- a/services/admin/handlers/createOneMacPackage.js
+++ b/services/admin/handlers/createOneMacPackage.js
@@ -64,7 +64,7 @@ export const createOneMacPackage = async (item) => {
     };
     try {
       const result = await dynamoDb.get(getParams).promise();
-      putParams.Item.attachments = { ...result.Item.attachments };
+      putParams.Item.attachments = [...result.Item.attachments];
     } catch (e) {
       console.log("%s error received: ", theID, e);
     }

--- a/services/admin/handlers/createOneMacPackage.js
+++ b/services/admin/handlers/createOneMacPackage.js
@@ -34,6 +34,7 @@ export const createOneMacPackage = async (item) => {
   const theID = item.componentId.toUpperCase();
   if (!item.territory)
     item.territory = item.componentId.toString().substring(0, 2);
+
   const putParams = {
     TableName: process.env.oneMacTableName,
     Item: {
@@ -52,6 +53,22 @@ export const createOneMacPackage = async (item) => {
       convertTimestamp: Date.now(),
     },
   };
+
+  if (item.copyAttachmentsFrom) {
+    const getParams = {
+      TableName: process.env.oneMacTableName,
+      Key: {
+        pk: item.copyAttachmentsFrom,
+        sk: "Package",
+      },
+    };
+    try {
+      const result = await dynamoDb.get(getParams).promise();
+      putParams.Item.attachments = { ...result.Item.attachments };
+    } catch (e) {
+      console.log("%s error received: ", theID, e);
+    }
+  }
 
   if (item.waiverAuthority)
     putParams.Item.waiverAuthority = item.waiverAuthority;

--- a/services/admin/handlers/createOneMacPackage.json
+++ b/services/admin/handlers/createOneMacPackage.json
@@ -4,5 +4,6 @@
     "componentType": "Medicaid SPA",
     "waiverAuthority": null,
     "submissionDate": "04/14/2022",
-    "additionalInformation": "This package was created outside the OneMAC application."
+    "additionalInformation": "This package was created outside the OneMAC application.",
+    "copyAttachmentsFrom": ""
 }


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24262
Endpoint: See github-actions bot comment

### Details
Splitting packages can mean that the attachments are relevant to both packages, so use the NOSO lambda with an extra ability to grab the attachments from a different package.

### Changes
- if "copyAttachmentsFrom" is designated in the NOSO event, copy the attachment information from the given package.
- updated the createOneMACPackage.json to include an example usage of this variable

### Test Plan
1. Login to OneMAC and find a package you would like to "split"
2. Login to AWS Console and navigate to Lambda > Functions > admin-oy2-24262-createOneMacPackage lambda
3. copy the sample JSON into the test event area
4. update the sample to reflect the package details for Instruction 1
5. run the test
6. Refresh the dashboard
7. Verify the new package is on the dashboard with the details submitted and contains the attachments from the starting package.
