### PR TITLE
Update default state and position of CPOC Name column

### DIFF
--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -42,8 +42,8 @@ import {
 import { portalTableExportToCSV } from "../utils/portalTableExportToCSV";
 import { FORM_SOURCE } from "../domain-types";
 
-const defaultStateHiddenCols = ["territory"];
-const defaultCMSHiddenCols = ["submitter"];
+const defaultStateHiddenCols = ["territory", "cpocName"];
+const defaultCMSHiddenCols = ["submitter", "cpocName"];
 
 const DEFAULT_COLUMNS = {
   [USER_ROLE.STATE_SUBMITTER]: defaultStateHiddenCols,
@@ -226,12 +226,6 @@ const PackageList = () => {
           filter: CustomFilterTypes.DateRange,
           Filter: CustomFilterUi.DateRangeInPast,
         },
-        {
-          Header: "CPOC Name",
-          accessor: "cpocName",
-          id: "cpocName",
-          disableGlobalFilter: false,
-        },
         userRoleObj.isCMSUser
           ? {
               Header: "Formal RAI Received",
@@ -249,6 +243,13 @@ const PackageList = () => {
               filter: CustomFilterTypes.DateRange,
               Filter: CustomFilterUi.DateRangeInPast,
             },
+
+        {
+          Header: "CPOC Name",
+          accessor: "cpocName",
+          id: "cpocName",
+          disableGlobalFilter: false,
+        },
         {
           Header: "Submitted By",
           accessor: "submitterName",


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24190

### Details

This PR moves the CPOC Name column and updates its default state for both CMS and State users to hidden. It's enabled via the Show/Hide Columns ui.

### Changes

- Change column order according to AC
- Hide column for State and CMS users by default

### Implementation Notes

N/A

### Test Plan

1. Log in as a CMS user
2. Navigate to Dashboard
3. Ensure the CPOC Name column is not shown by default
4. Enable it
5. Ensure the CPOC Name column is between Formal RAI Received and Submitted By
6. Log out

Repeat steps 1-6 as a State user, noting that the Formal RAI Received column will be Formal RAI Response for State users. 
