### PR TITLE
OY2 24058: BUG - When the ID isn't found, OneMac shows an empty details page

### DIFF
--- a/services/ui-src/src/page/DetailView.tsx
+++ b/services/ui-src/src/page/DetailView.tsx
@@ -147,7 +147,7 @@ const DetailView: React.FC<{ pageConfig: OneMACDetail }> = ({ pageConfig }) => {
       if (!ctrlr?.signal.aborted) setDetail(fetchedDetail);
       if (!ctrlr?.signal.aborted) setIsLoading(stillLoading);
     },
-    [history, componentId, componentType, componentTimestamp]
+    [goBackLink, history, componentId, componentType, componentTimestamp]
   );
 
   useEffect(() => {

--- a/services/ui-src/src/page/DetailView.tsx
+++ b/services/ui-src/src/page/DetailView.tsx
@@ -15,6 +15,7 @@ import PackageApi from "../utils/PackageApi";
 import { formatDate } from "../utils/date-utils";
 import PageTitleBar from "../components/PageTitleBar";
 import AlertBar from "../components/AlertBar";
+import NotFound from "../containers/NotFound";
 import { OneMACDetail } from "../libs/detailLib";
 import { DetailSection } from "./section/DetailSection";
 import { temporaryExtensionTypes } from "./temporary-extension/TemporaryExtensionForm";
@@ -137,7 +138,7 @@ const DetailView: React.FC<{ pageConfig: OneMACDetail }> = ({ pageConfig }) => {
       } catch (e) {
         console.log("error in getDetail call?? ", e);
         history.push({
-          pathname: ONEMAC_ROUTES.PACKAGE_LIST,
+          pathname: goBackLink,
           state: {
             passCode: RESPONSE_CODE.SYSTEM_ERROR,
           },
@@ -161,25 +162,29 @@ const DetailView: React.FC<{ pageConfig: OneMACDetail }> = ({ pageConfig }) => {
 
   return (
     <LoadingScreen isLoading={isLoading}>
-      <PageTitleBar
-        backTo={goBackLink}
-        heading={detail && detail.componentId}
-        enableBackNav
-      />
-      <AlertBar alertCode={alertCode} closeCallback={closedAlert} />
-      {detail && (
-        <div className="form-container">
-          <div className="component-detail-wrapper">
-            <article className="component-detail">
-              <DetailSection
-                pageConfig={pageConfig}
-                detail={detail}
-                loadDetail={loadDetail}
-                setAlertCode={setAlertCode}
-              />
-            </article>
+      {detail?.componentId ? (
+        <>
+          <PageTitleBar
+            backTo={goBackLink}
+            heading={detail && detail.componentId}
+            enableBackNav
+          />
+          <AlertBar alertCode={alertCode} closeCallback={closedAlert} />
+          <div className="form-container">
+            <div className="component-detail-wrapper">
+              <article className="component-detail">
+                <DetailSection
+                  pageConfig={pageConfig}
+                  detail={detail}
+                  loadDetail={loadDetail}
+                  setAlertCode={setAlertCode}
+                />
+              </article>
+            </div>
           </div>
-        </div>
+        </>
+      ) : (
+        <NotFound />
       )}
     </LoadingScreen>
   );


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24058
Endpoint: See github-actions bot comment

### Details
if you change the package id in the url of the details page, it showed a weird, empty, details page.  We would rather it show a "page not found"

### Changes
- added the "NotFound" component to the details page
- restructured the page so that if the componentId is not in the response for fetch details, display "NotFound"

### Implementation Notes
- Added the component instead of manipulating the routes or history because I thought it would be better to maintain the URL - but that's just personal preference.

### Test Plan
1. Login and navigate to Dashboard
2. Select a package from the table and open its details
3. Click into the URL and change the ID to something not in the database
4. Verify "NotFound" is shown and looks like other "Page not found" pages
5. change the URL to a valid package
6. Verify detail page is correct again.
