### PR TITLE
Oy2 24437 - generate signed urls for withdrawal attachments on detail view

### DIFF
--- a/services/app-api/getDetail.js
+++ b/services/app-api/getDetail.js
@@ -24,6 +24,12 @@ async function assignAttachmentUrls(item) {
       item.attachments[idx].url = url;
     });
   }
+
+  for (const child in item) {
+    if (child?.attachments) {
+      await assignAttachmentUrls(child);
+    }
+  }
 }
 export const getDetails = async (event) => {
   const componentId = event?.pathParameters?.id;
@@ -58,11 +64,17 @@ export const getDetails = async (event) => {
 
     await assignAttachmentUrls(result.Item);
 
-    if (result.Item?.raiResponses.length > 0) {
-      for (const child of result.Item?.raiResponses) {
-        await assignAttachmentUrls(child);
-      }
-    }
+    // if (result.Item?.raiResponses.length > 0) {
+    //   for (const child of result.Item?.raiResponses) {
+    //     await assignAttachmentUrls(child);
+    //   }
+    // }
+
+    // if (result.Item?.withdrawalRequests.length > 0) {
+    //   for (const child of result.Item?.raiResponses) {
+    //     await assignAttachmentUrls(child);
+    //   }
+    // }
 
     result.Item.currentStatus = userRoleObj.isCMSUser
       ? cmsStatusUIMap[result.Item.currentStatus]


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24437
Endpoint: See github-actions bot comment

### Details

Generate signed urls for attachments on withdrawal requests so that they can be downloaded.

### Changes

- Add logic to generate presigned urls for withdrawalRequests object
- Moved all generation of all signed urls (package, rai response, withdrawal requests) to be within single method 

### Implementation Notes

- I did try a fancy pants recursive function that would look at an object for an attachments array, generate urls, and then call itself for each remaining property. This could have auto covered any future additions of attachments as sub objects however turned out to be too fancy pants and as recursion usually is was not as easy to follow or easily root out side issues. I figured that was a sign to do it simply and declaratively with known objects. :)

### Test Plan

1. Login as state submitter
2. Create a package with attachments and set its status to Under Review or locate an existing package
3. Perform withdraw action on the package and include an attachment
4. Open details page and verify the main package attachments and the withdrawal attachment can be downloaded.
5. Also try an rai response just to be sure.
