### PR TITLE
Add Character Counter w/ Aria for Screen Reader

### DIFF
--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -63,6 +63,15 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
   const { activeTerritories, confirmAction } = useAppContext() ?? {};
   const location = useLocation<FormLocationState>();
 
+  // Boolean controlling aria-busy for Additional Info section
+  const [isTyping, setIsTyping] = useState<boolean>();
+  // Effect to timeout and swap isTyping back to false
+  useEffect(() => {
+    const timeTilInactive = setTimeout(() => setIsTyping(false), 500);
+    return () => {
+      clearTimeout(timeTilInactive);
+    };
+  }, [isTyping]);
   //Reference to the File Uploader.
   const uploader = useRef<FileUploader>(null);
   // True when the required attachments have been selected.
@@ -523,19 +532,22 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
             disabled={isSubmitting}
             fieldClassName="summary-field"
             multiline
-            onChange={handleInputChange}
+            onChange={(e) => {
+              handleInputChange(e);
+              setIsTyping(true);
+            }}
             value={oneMacFormData.additionalInformation}
             maxLength={config.MAX_ADDITIONAL_INFO_LENGTH}
             aria-describedby="character-count"
             aria-live="off"
             aria-multiline={true}
-            //todo: aria-busy logic
+            aria-busy={isTyping}
           ></TextField>
           <span
             tabIndex={0}
             aria-label="character-count"
             aria-live="polite"
-            //todo: aria-busy logic
+            aria-busy={isTyping}
           >
             {oneMacFormData.additionalInformation.length}/4000
           </span>

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -526,7 +526,19 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
             onChange={handleInputChange}
             value={oneMacFormData.additionalInformation}
             maxLength={config.MAX_ADDITIONAL_INFO_LENGTH}
+            aria-describedby="character-count"
+            aria-live="off"
+            aria-multiline={true}
+            //todo: aria-busy logic
           ></TextField>
+          <span
+            tabIndex={0}
+            aria-label="character-count"
+            aria-live="polite"
+            //todo: aria-busy logic
+          >
+            {oneMacFormData.additionalInformation.length}/4000
+          </span>
           <p id="form-submit-instructions">
             <i>
               Once you submit this form, a confirmation email is sent to you and


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-23575

### Details

This PR adds a 4000-word character counter to the Additional Information section of OneMAC forms. It's built to debounce the read-back using the `aria-busy` tag and React state logic. The debounce is set to 500ms per the AC. Using `aria-live` off, immediate updates to the additional information will not be read, and updates to the character count will only happen if nothing else is being read out (i.e. "polite" setting). 

### Changes

- Adds Character Counter
- Adds aria tags to character counter for proper readout

### Implementation Notes

- I'm not sure 500ms is long enough of a debounce, but the AC dictates all.

### Test Plan

1. Turn on a screen reading tool like MacOS's VoiceOver
2. Navigate to a form page with an additional info box
3. Assert the character counter is present
4. Assert the character counter reads your count after you're done typing
