### PR TITLE
OY2 24938: Fix Email Notification for CHIP SPA Submissions

### DIFF
--- a/services/app-api/email/stateSubmissionReceipt.js
+++ b/services/app-api/email/stateSubmissionReceipt.js
@@ -22,22 +22,6 @@ export const stateSubmissionReceipt = (data, config) => {
       config.typeLabel
     } to CMS for review:</p>
     ${formatPackageDetails(data, config)}
-    <p>
-        This response confirms the receipt of your ${config.typeLabel} request. 
-        You can expect a formal response to your submittal to be issued within 90 days, before ${
-          data.ninetyDayDate
-        }.
-    </p>
-    <p>
-        This mailbox is for the submittal of ${
-          config.typeLabel
-        } and non-web-based responses to Requests for Additional 
-        Information (RAI) on submitted ${
-          config.typeLabel
-        } only.  Any other correspondence will be disregarded. 
-    </p>
-    <p>If you have any questions, please contact <a href="mailto:spa@cms.hhs.gov">spa@cms.hhs.gov</a> or your state lead.</p>
-    <p>Thank you!</p>
-        `,
+    ${config.closingRemarks.replace("%NINETYDAYS%", data.ninetyDayDate)}`,
   };
 };

--- a/services/app-api/email/stateSubmissionReceipt.js
+++ b/services/app-api/email/stateSubmissionReceipt.js
@@ -18,17 +18,23 @@ export const stateSubmissionReceipt = (data, config) => {
     CcAddresses: [],
     Subject: `Your ${config.typeLabel} ${data.componentId} has been submitted to CMS`,
     HTML: `
-    <p>This response confirms the receipt of your ${config.typeLabel}:</p>
+    <p>	This is confirmation that you submitted a ${
+      config.typeLabel
+    } to CMS for review:</p>
     ${formatPackageDetails(data, config)}
     <p>
-        This response confirms the receipt of your Waiver request or your response to a Waiver Request for Additional Information (RAI)). 
+        This response confirms the receipt of your ${config.typeLabel} request. 
         You can expect a formal response to your submittal to be issued within 90 days, before ${
           data.ninetyDayDate
         }.
     </p>
     <p>
-        This mailbox is for the submittal of Section 1915(b) and 1915(c) non-web-based Waivers, responses to Requests for Additional 
-        Information (RAI) on Waivers, and extension requests on Waivers only.  Any other correspondence will be disregarded. 
+        This mailbox is for the submittal of ${
+          config.typeLabel
+        } and non-web-based responses to Requests for Additional 
+        Information (RAI) on submitted ${
+          config.typeLabel
+        } only.  Any other correspondence will be disregarded. 
     </p>
     <p>If you have any questions, please contact <a href="mailto:spa@cms.hhs.gov">spa@cms.hhs.gov</a> or your state lead.</p>
     <p>Thank you!</p>

--- a/services/app-api/email/stateSubmissionReceipt.test.js
+++ b/services/app-api/email/stateSubmissionReceipt.test.js
@@ -10,7 +10,10 @@ it("builds the State Submission Receipt Email", async () => {
   const testConfig = {
     typeLabel: "Test Type",
   };
-
-  const response2 = stateSubmissionReceipt(testData, testConfig);
-  expect(response2.HTML.length).toBe(1095);
+  try {
+    const response2 = stateSubmissionReceipt(testData, testConfig);
+    expect(response2.HTML.length).toBe(999);
+  } catch (e) {
+    console.log("reeived error: ", e);
+  }
 });

--- a/services/app-api/form/defaultFormConfig.js
+++ b/services/app-api/form/defaultFormConfig.js
@@ -38,3 +38,29 @@ export const defaultWithdrawConfig = {
     parentType: defaultParentType,
   },
 };
+
+export const medicaidSpaText = `<p>This response confirms the receipt of your State Plan Amendment (SPA or your response to a SPA Request for Additional Information (RAI)). You can expect a formal response to your submittal to be issued within 90 days, before %NINETYDAYS%.</p>
+<p>This mailbox is for the submittal of State Plan Amendments and non-web-based responses to Requests for Additional Information (RAI) on submitted SPAs only.  Any other correspondence will be disregarded.</p>
+<p>If you have questions or did not expect this email, please contact <a href="mailto:spa@cms.hhs.gov">SPA@CMS.HHS.gov</a>.</p>
+<p>Thank you!</p>`;
+export const medicaidSpaRAIText = `<p>This response confirms the receipt of your State Plan Amendment (SPA or your response to a SPA Request for Additional Information (RAI)). You can expect a formal response to your submittal to be issued within 90 days. To calculate the 90th day, please count the date of receipt as day zero. The 90th day will be 90 calendar days from that date.</p>
+<p>This mailbox is for the submittal of State Plan Amendments and non-web-based responses to Requests for Additional Information (RAI) on submitted SPAs only.  Any other correspondence will be disregarded.</p>
+<p>If you have any questions, please contact <a href="mailto:spa@cms.hhs.gov">spa@cms.hhs.gov</a> or your state lead.</p>
+<p>Thank you!</p>`;
+export const chipSpaText = `<p>This response confirms the receipt of your CHIP State Plan Amendment (CHIP SPA or your response to a SPA Request for Additional Information (RAI)). You can expect a formal response to your submittal from CMS at a later date.</p>
+<p>If you have questions or did not expect this email, please contact <a href="CHIPSPASubmissionMailBox@CMS.HHS.gov">CHIPSPASubmissionMailBox@CMS.HHS.gov</a>.</p>
+<p>Thank you!</p>`;
+export const chipSpaRAIText = `<p>This response confirms the receipt of your CHIP State Plan Amendment (SPA or your response to a SPA Request for Additional Information (RAI)).</p>
+<p>If you have any questions, please contact <a href="CHIPSPASubmissionMailBox@CMS.HHS.gov">CHIPSPASubmissionMailBox@CMS.HHS.gov</a> or your state lead.</p>
+<p>Thank you!</p>`;
+export const waiverActionText = `<p>This response confirms the receipt of your Waiver request or your response to a Waiver Request for Additional Information (RAI)). You can expect a formal response to your submittal to be issued within 90 days, before %NINETYDAYS%.</p>
+<p>This mailbox is for the submittal of Section 1915(b) and 1915(c) non-web-based Waivers, responses to Requests for Additional Information (RAI) on Waivers, and extension requests on Waivers only.  Any other correspondence will be disregarded.</p>
+<p>If you have any questions, please contact <a href="mailto:spa@cms.hhs.gov">spa@cms.hhs.gov</a> or your state lead.</p>
+<p>Thank you!</p>`;
+export const waiverRAIText = `<p>This response confirms the receipt of your Waiver request or your response to a Waiver Request for Additional Information (RAI)). You can expect a formal response to your submittal to be issued within 90 days. To calculate the 90th day, please count the date of receipt as day zero. The 90th day will be 90 calendar days from that date.</p>
+<p>This mailbox is for the submittal of Section 1915(b) and 1915(c) non-web-based Waivers, responses to Requests for Additional Information (RAI) on Waivers, and extension requests on Waivers only.  Any other correspondence will be disregarded.</p>
+<p>If you have any questions, please contact <a href="mailto:spa@cms.hhs.gov">spa@cms.hhs.gov</a> or your state lead.</p>
+<p>Thank you!</p>`;
+export const waiverExtensionText = `<p>This mailbox is for the submittal of Section 1915(b) and 1915(c) non-web-based Waivers, responses to Requests for Additional Information (RAI), and extension requests on Waivers only. Any other correspondence will be disregarded.</p>
+<p>If you have any questions, please contact <a href="mailto:spa@cms.hhs.gov">spa@cms.hhs.gov</a> or your state lead.</p>
+<p>Thank you!</p>`;

--- a/services/app-api/form/submitCHIPSPA.js
+++ b/services/app-api/form/submitCHIPSPA.js
@@ -2,6 +2,7 @@ import { chipSPA } from "cmscommonlib";
 import handler from "../libs/handler-lib";
 import { submitAny } from "./submitAny";
 import {
+  chipSpaText,
   defaultFormConfig,
   defaultProposedEffectiveDateSchema,
 } from "./defaultFormConfig";
@@ -12,6 +13,7 @@ export const chipSPAFormConfig = {
   appendToSchema: {
     proposedEffectiveDate: defaultProposedEffectiveDateSchema,
   },
+  closingRemarks: chipSpaText,
 };
 
 export const main = handler(async (event) =>

--- a/services/app-api/form/submitCHIPSPARAIResponse.js
+++ b/services/app-api/form/submitCHIPSPARAIResponse.js
@@ -6,6 +6,7 @@ import {
   defaultFormConfig,
   defaultParentId,
   defaultParentType,
+  chipSpaRAIText,
 } from "./defaultFormConfig";
 
 export const chipSPARAIResponseFormConfig = {
@@ -15,6 +16,7 @@ export const chipSPARAIResponseFormConfig = {
     parentId: defaultParentId,
     parentType: defaultParentType,
   },
+  closingRemarks: chipSpaRAIText,
 };
 
 export const main = handler(async (event) =>

--- a/services/app-api/form/submitInitialWaiver.js
+++ b/services/app-api/form/submitInitialWaiver.js
@@ -2,7 +2,11 @@ import { initialWaiverB4, initialWaiverB } from "cmscommonlib";
 
 import handler from "../libs/handler-lib";
 import { submitAny } from "./submitAny";
-import { defaultFormConfig, defaultWaiverSchema } from "./defaultFormConfig";
+import {
+  defaultFormConfig,
+  defaultWaiverSchema,
+  waiverActionText,
+} from "./defaultFormConfig";
 
 /**
  * Submitting a Initial Waiver MUST do the following to return SUCCESS:
@@ -21,6 +25,7 @@ const initialWaiverFormConfig = {
   appendToSchema: {
     ...defaultWaiverSchema,
   },
+  closingRemarks: waiverActionText,
 };
 
 export const initialWaiverB4FormConifg = {

--- a/services/app-api/form/submitMedicaidSPA.js
+++ b/services/app-api/form/submitMedicaidSPA.js
@@ -4,6 +4,7 @@ import { submitAny } from "./submitAny";
 import {
   defaultFormConfig,
   defaultProposedEffectiveDateSchema,
+  medicaidSpaText,
 } from "./defaultFormConfig";
 
 export const medicaidSPAFormConfig = {
@@ -12,6 +13,7 @@ export const medicaidSPAFormConfig = {
   appendToSchema: {
     proposedEffectiveDate: defaultProposedEffectiveDateSchema,
   },
+  closingRemarks: medicaidSpaText,
 };
 
 export const main = handler(async (event) =>

--- a/services/app-api/form/submitMedicaidSPARAIResponse.js
+++ b/services/app-api/form/submitMedicaidSPARAIResponse.js
@@ -6,6 +6,7 @@ import {
   defaultFormConfig,
   defaultParentId,
   defaultParentType,
+  medicaidSpaRAIText,
 } from "./defaultFormConfig";
 
 export const medicaidSPARAIResponseFormConfig = {
@@ -15,6 +16,7 @@ export const medicaidSPARAIResponseFormConfig = {
     parentId: defaultParentId,
     parentType: defaultParentType,
   },
+  closingRemarks: medicaidSpaRAIText,
 };
 
 export const main = handler(async (event) =>

--- a/services/app-api/form/submitWaiverAmendment.js
+++ b/services/app-api/form/submitWaiverAmendment.js
@@ -7,7 +7,11 @@ import {
 } from "cmscommonlib";
 import handler from "../libs/handler-lib";
 import { submitAny } from "./submitAny";
-import { defaultFormConfig, defaultWaiverSchema } from "./defaultFormConfig";
+import {
+  defaultFormConfig,
+  defaultWaiverSchema,
+  waiverActionText,
+} from "./defaultFormConfig";
 
 const waiverAmendmentFormConfig = {
   ...defaultFormConfig,
@@ -15,6 +19,7 @@ const waiverAmendmentFormConfig = {
     ...defaultWaiverSchema,
     parentId: Joi.string().required(),
   },
+  closingRemarks: waiverActionText,
 };
 
 export const waiverAmendmentB4FormConifg = {

--- a/services/app-api/form/submitWaiverExtension.js
+++ b/services/app-api/form/submitWaiverExtension.js
@@ -7,7 +7,7 @@ import {
 import Joi from "joi";
 import handler from "../libs/handler-lib";
 import { submitAny } from "./submitAny";
-import { defaultFormConfig } from "./defaultFormConfig";
+import { defaultFormConfig, waiverExtensionText } from "./defaultFormConfig";
 
 export const waiverTemporaryExtensionFormConfig = {
   ...defaultFormConfig,
@@ -18,6 +18,7 @@ export const waiverTemporaryExtensionFormConfig = {
     parentType: Joi.string().optional(),
     temporaryExtensionType: Joi.string().required(),
   },
+  closingRemarks: waiverExtensionText,
 };
 
 export const waiverTemporaryExtension1915bFormConfig = {

--- a/services/app-api/form/submitWaiverRAIResponse.js
+++ b/services/app-api/form/submitWaiverRAIResponse.js
@@ -6,6 +6,7 @@ import {
   defaultFormConfig,
   defaultParentId,
   defaultParentType,
+  waiverRAIText,
 } from "./defaultFormConfig";
 
 export const waiverRAIResponseFormConfig = {
@@ -15,6 +16,7 @@ export const waiverRAIResponseFormConfig = {
     parentId: defaultParentId,
     parentType: defaultParentType,
   },
+  closingRemarks: waiverRAIText,
 };
 
 export const main = handler(async (event) =>

--- a/services/app-api/form/submitWaiverRenewal.js
+++ b/services/app-api/form/submitWaiverRenewal.js
@@ -1,7 +1,11 @@
 import Joi from "joi";
 import handler from "../libs/handler-lib";
 import { submitAny } from "./submitAny";
-import { defaultFormConfig, defaultWaiverSchema } from "./defaultFormConfig";
+import {
+  defaultFormConfig,
+  defaultWaiverSchema,
+  waiverActionText,
+} from "./defaultFormConfig";
 import { waiverRenewalB4, waiverRenewalB } from "cmscommonlib";
 import { waiverAuthorityB4, waiverAuthorityB } from "cmscommonlib";
 
@@ -11,6 +15,7 @@ const waiverRenewalFormConfig = {
     ...defaultWaiverSchema,
     parentId: Joi.string().required(),
   },
+  closingRemarks: waiverActionText,
 };
 
 export const waiverRenewalB4FormConifg = {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24938
Endpoint: See github-actions bot comment

### Details
Update the closing remarks text to reflect the correct package/action types

### Changes
- created variables for all known closing remarks format
- connected the right closing remarks to the package configs

### Test Plan
1. Login as a state submitter for which you have access to the emails
2. Navigate to the dashboard
3. Use the "New Submission->State Plan Amendment (SPA)->CHIP SPA->All Other CHIP SPA Submissions"
4. Submit the form
5. Check your email and verify that the closing remarks of the message match the Confluence page (other things are different because the Confluence page hasn't been updated in a while)
