### PR TITLE
OY2 25051: Withdraw Formal RAI Response - Email (Revised)

### DIFF
--- a/services/app-api/email/CMSWithdrawRaiNotice.js
+++ b/services/app-api/email/CMSWithdrawRaiNotice.js
@@ -66,9 +66,7 @@ export const CMSWithdrawRaiNotice = async (data, config, user) => {
       CcAddresses: config.CMSCcAddresses,
       Subject: `${config.typeLabel} ${data.componentId} Withdraw Request`,
       HTML: `<>The OneMAC submission portal received a request to withdraw the Formal RAI Response. You are receiving this email notification as the Formal RAI for 
-  ${data.componentId} was withdrawn by ${user.fullName} (${
-        user.email
-      }). The package will revert to the “RAI Issued” status.</p>
+  ${data.componentId} was withdrawn by ${user.fullName} (${user.email}).</p>
    ${formatPackageDetails(data, config)}
    <p>Thank you!</p>
    `,

--- a/services/app-api/email/CMSWithdrawalRaiNotice.test.js
+++ b/services/app-api/email/CMSWithdrawalRaiNotice.test.js
@@ -38,19 +38,19 @@ it("builds the CMS Withdraw RAI Response Notice Email", async () => {
   });
   try {
     let response = await CMSWithdrawRaiNotice(testData, testConfig, user);
-    expect(response.HTML.length).toBe(513);
+    expect(response.HTML.length).toBe(461);
 
     testData.parentType = ONEMAC_TYPE.CHIP_SPA;
     response = await CMSWithdrawRaiNotice(testData, testConfig, user);
-    expect(response.HTML.length).toBe(513);
+    expect(response.HTML.length).toBe(461);
 
     testData.parentType = ONEMAC_TYPE.WAIVER_INITIAL;
     response = await CMSWithdrawRaiNotice(testData, testConfig, user);
-    expect(response.HTML.length).toBe(513);
+    expect(response.HTML.length).toBe(461);
 
     testData.parentType = ONEMAC_TYPE.WAIVER_APP_K;
     response = await CMSWithdrawRaiNotice(testData, testConfig, user);
-    expect(response.HTML.length).toBe(513);
+    expect(response.HTML.length).toBe(461);
   } catch (e) {
     console.log("reeived error: ", e);
   }

--- a/services/app-api/email/stateWithdrawRaiReceipt.js
+++ b/services/app-api/email/stateWithdrawRaiReceipt.js
@@ -15,9 +15,7 @@ export const stateWithdrawRaiReceipt = async (data, config, user) => {
     HTML: `
         <p>The OneMAC submission portal received a request to withdraw the Formal RAI Response. You are receiving this email notification as the Formal RAI for ${
           data.componentId
-        } was withdrawn by ${user.fullName} (${
-      user.email
-    }).  The package will revert to the “RAI Issued” status.</p>
+        } was withdrawn by ${user.fullName} (${user.email}).</p>
         ${formatPackageDetails(data, config)}
         <p>Thank you!</p>
         `,

--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -7386,14 +7386,14 @@
   },
   {
     "componentType": "chipspa",
-    "eventTimestamp": 1674139607941,
+    "eventTimestamp": 1675603949000,
     "currentStatus": "Withdrawal Requested",
     "GSI1sk": "MD-22-2307-VM",
     "GSI1pk": "OneMAC#withdrawchipspa",
     "lastModifiedEmail": "statesubmitter@nightwatch.test",
     "changedByName": "Statesubmitter Nightwatch",
     "changedByEmail": "statesubmitter@nightwatch.test",
-    "sk": "OneMAC#1674139607941",
+    "sk": "OneMAC#1675603949000",
     "componentId": "MD-22-2307-VM",
     "pk": "MD-22-2307-VM",
     "lastModifiedName": "Statesubmitter Nightwatch"
@@ -26216,7 +26216,7 @@
       "ADDED_COST": null,
       "MISSING_INFORMATION": null,
       "PRIORITY_COMPLEXITY_ID": null,
-      "ACTION_TYPE": 73,
+      "ACTION_TYPE": 75,
       "PENDING_CONCURRENCE_DATE": 1674172800000,
       "PUBLICHEALTH_STATEEMERGENCY": null,
       "COMPONENT_ID": null,
@@ -49436,7 +49436,7 @@
       "ADDED_COST": null,
       "MISSING_INFORMATION": null,
       "PRIORITY_COMPLEXITY_ID": null,
-      "ACTION_TYPE": null,
+      "ACTION_TYPE": 76,
       "PENDING_CONCURRENCE_DATE": null,
       "PUBLICHEALTH_STATEEMERGENCY": null,
       "COMPONENT_ID": null,
@@ -49485,7 +49485,13 @@
         "SPW_STATUS_DESC": "Pending"
       }
     ],
-    "ACTIONTYPES": null,
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "New",
+        "ACTION_ID": 76
+      }
+    ],
     "SP_TYPE": null,
     "SP_APD_SUB_TYPE": null,
     "STATE_PLAN_SERVICE_SUBTYPES": null,
@@ -49661,7 +49667,7 @@
       "INITIAL_SUBMISSION_COMPLETE": true,
       "MISSING_INFORMATION": null,
       "PRIORITY_COMPLEXITY_ID": null,
-      "ACTION_TYPE": null,
+      "ACTION_TYPE": 76,
       "PENDING_CONCURRENCE_DATE": null,
       "PUBLICHEALTH_STATEEMERGENCY": null,
       "BUDGET_IMPACT_VALUE": null,
@@ -49715,7 +49721,13 @@
         "SPW_STATUS_ID": 1
       }
     ],
-    "ACTIONTYPES": null,
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "New",
+        "ACTION_ID": 76
+      }
+    ],
     "SP_TYPE": null,
     "SP_APD_SUB_TYPE": null,
     "STATE_PLAN_SERVICE_SUBTYPES": [
@@ -49995,7 +50007,7 @@
     "ACTIONTYPES": [
       {
         "PLAN_TYPE_ID": 122,
-        "ACTION_NAME": "Amend",
+        "ACTION_NAME": "New",
         "ACTION_ID": 76
       }
     ],


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-25051
Endpoint: See github-actions bot comment

### Details
A small edit to the email static text in the Withdraw RAI Response emails.

### Changes
- removed the "The package will revert to the “RAI Issued” status." sentence from the CMS notification email
- removed the "The package will revert to the “RAI Issued” status." sentence from the State confirmation email
- updated some seed data based on failing tests due to wonky data

### Test Plan
1. Login as a state submitting user for whom you will receive emails
2. Navigate to dashboard
3. Complete an RAI Response Withdraw form for an applicable package (any type)
4. Verify the emails do not contain "The package will revert to the “RAI Issued” status." sentence
