### PR TITLE
OY2 23552: Latest Package Activity - Package Details Page + Dashboard

### DIFF
--- a/services/app-api/getMyPackages.js
+++ b/services/app-api/getMyPackages.js
@@ -39,7 +39,7 @@ export const getMyPackages = async (email, group) => {
         ExclusiveStartKey: null,
         ScanIndexForward: false,
         ProjectionExpression:
-          "componentId,componentType,currentStatus,submissionTimestamp,latestRaiResponseTimestamp,submitterName,submitterEmail,waiverAuthority, cpocName, reviewTeam",
+          "componentId,componentType,currentStatus,submissionTimestamp,latestRaiResponseTimestamp,lastActivityTimestamp,submitterName,submitterEmail,waiverAuthority, cpocName",
       };
       const grouppk = "OneMAC#" + group;
       let paramList = [];

--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -69,6 +69,7 @@ export const buildAnyPackage = async (packageId, config) => {
         reviewTeam: [],
         reviewTeamEmailList: [],
         adminChanges: [],
+        lastActivityTimestamp: 0,
       },
     };
     let currentPackage;
@@ -107,6 +108,9 @@ export const buildAnyPackage = async (packageId, config) => {
         if (anEvent?.currentStatus === Workflow.ONEMAC_STATUS.INACTIVATED)
           return;
         showPackageOnDashboard = true;
+
+        if (anEvent.eventTimestamp > putParams.Item.lastActivityTimestamp)
+          putParams.Item.lastActivityTimestamp = anEvent.eventTimestamp;
 
         if (anEvent?.componentType)
           if (anEvent?.adminChanges && _.isArray(anEvent.adminChanges))

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -48,6 +48,7 @@ export const COLUMN_ID = {
   TYPE: "componentType",
   STATUS: "packageStatus",
   SUBMISSION_TIMESTAMP: "submissionTimestamp",
+  ACTIVITY_TIMESTAMP: "lastActivityTimestamp",
   LATEST_RAI_TIMESTAMP: "latestRaiResponseTimestamp",
   CPOC_NAME: "cpocName",
   SUBMITTER: "submitter",
@@ -239,6 +240,14 @@ const PackageList = () => {
         {
           Header: "Initial Submission",
           accessor: COLUMN_ID.SUBMISSION_TIMESTAMP,
+          Cell: renderDate,
+          disableFilters: false,
+          filter: CustomFilterTypes.DateRange,
+          Filter: CustomFilterUi.DateRangeInPast,
+        },
+        {
+          Header: "Latest Package Activity",
+          accessor: COLUMN_ID.ACTIVITY_TIMESTAMP,
           Cell: renderDate,
           disableFilters: false,
           filter: CustomFilterTypes.DateRange,

--- a/services/ui-src/src/libs/detailLib.ts
+++ b/services/ui-src/src/libs/detailLib.ts
@@ -28,6 +28,11 @@ export const submissionIdDefault: AttributeDetail = {
   fieldName: "componentId",
   default: null,
 };
+export const latestActivityDefault: AttributeDetail = {
+  heading: "Latest Package Activity",
+  fieldName: "lastActivityNice",
+  default: null,
+};
 export const submissionDateDefault: AttributeDetail = {
   heading: "Initial Submission Date",
   fieldName: "submissionDateNice",
@@ -130,7 +135,7 @@ export const defaultPackageOverviewLabel: string = "Package Overview";
 
 export const defaultDetailSectionItems = [
   submissionIdDefault,
-  blankBox, // empty space
+  latestActivityDefault,
   territoryDefault,
   typeDefault,
   submissionDateDefault,

--- a/services/ui-src/src/libs/detailLib.ts
+++ b/services/ui-src/src/libs/detailLib.ts
@@ -150,6 +150,8 @@ export const defaultDetailSectionItems = [
 ];
 
 export const defaultWaiverDetailSectionItems = [
+  submissionIdDefault,
+  latestActivityDefault,
   waiverAuthorityDefault,
   blankBox, // empty space
   territoryDefault,

--- a/services/ui-src/src/libs/detailLib.ts
+++ b/services/ui-src/src/libs/detailLib.ts
@@ -31,7 +31,7 @@ export const submissionIdDefault: AttributeDetail = {
 export const latestActivityDefault: AttributeDetail = {
   heading: "Latest Package Activity",
   fieldName: "lastActivityNice",
-  default: null,
+  default: "-- --",
 };
 export const submissionDateDefault: AttributeDetail = {
   heading: "Initial Submission Date",

--- a/services/ui-src/src/page/DetailView.tsx
+++ b/services/ui-src/src/page/DetailView.tsx
@@ -41,6 +41,8 @@ export type ComponentDetail = {
   currentStatus: string;
   attachments: any[];
   submissionTimestamp: Date;
+  lastActivityTimestamp?: Date;
+  lastActivityNice?: string;
   clockEndTimestamp: Date;
   proposedEffectiveDate: string;
   effectiveDateTimestamp: Date;
@@ -121,6 +123,11 @@ const DetailView: React.FC<{ pageConfig: OneMACDetail }> = ({ pageConfig }) => {
         if (fetchedDetail.latestRaiResponseTimestamp) {
           fetchedDetail.latestRaiResponseDateNice = formatDate(
             fetchedDetail.latestRaiResponseTimestamp
+          );
+        }
+        if (fetchedDetail.lastActivityTimestamp) {
+          fetchedDetail.lastActivityNice = formatDate(
+            fetchedDetail.lastActivityTimestamp
           );
         }
         if (fetchedDetail.proposedEffectiveDate) {

--- a/services/ui-src/src/page/temporary-extension/TemporaryExtensionDetail.tsx
+++ b/services/ui-src/src/page/temporary-extension/TemporaryExtensionDetail.tsx
@@ -5,6 +5,7 @@ import {
   defaultDetail,
   submissionDateDefault,
   AttributeDetail,
+  latestActivityDefault,
 } from "../../libs/detailLib";
 import { waiverTemporaryExtension } from "cmscommonlib";
 
@@ -37,6 +38,7 @@ export const waiverTemporaryExtensionDetail: OneMACDetail = {
     parentIdDetail,
     temporaryExtensionTypeDetail,
     submissionDateDefault,
+    latestActivityDefault,
   ],
 };
 

--- a/services/ui-src/src/page/waiver-appendix-k/WaiverAppendixKDetail.tsx
+++ b/services/ui-src/src/page/waiver-appendix-k/WaiverAppendixKDetail.tsx
@@ -13,6 +13,8 @@ import {
   waiverAuthorityDefault,
   cpocDefault,
   blankBox,
+  submissionIdDefault,
+  latestActivityDefault,
 } from "../../libs/detailLib";
 import { waiverAppendixK } from "cmscommonlib";
 
@@ -27,6 +29,8 @@ export const waiverAppendixKDetail: OneMACDetail = {
   detailHeader: "Appendix K Amendment Package",
   attachmentsHeading: "Attachments",
   detailSection: [
+    submissionIdDefault,
+    latestActivityDefault,
     appendixKWaiverAuthority,
     territoryDefault,
     {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-23552
Endpoint: See github-actions bot comment

### Details
Knowing the last OneMAC Action taken is something the users want to see.   It is called the "Last Package Activity"

### Changes
- added the lastActivityTimestamp attribute to the Package Item
- included it in the getMyPackages projection
- set the value in the package builder according to the story AC
- added the column to the dashboard
- added the field to the details pages in the assigned spots
- added the submission ID field to the details pages, where requested.

### Test Plan
1. Login as a 
2. Test step 2
