### PR TITLE
OY2 25093: Remove 2nd Clock Status from CHIP SPAs

### DIFF
--- a/services/common/type/initialWaiver.js
+++ b/services/common/type/initialWaiver.js
@@ -29,6 +29,11 @@ export const initialWaiver = {
     "submitterEmail",
     "waiverAuthority",
   ],
+  secondClockStatuses: [
+    "Pending",
+    "Pending - Concurrence",
+    "Pending - Approval",
+  ],
 };
 
 export const initialWaiverB4 = {

--- a/services/common/type/medicaidSPA.js
+++ b/services/common/type/medicaidSPA.js
@@ -31,4 +31,9 @@ export const medicaidSPA = {
     "submitterName",
     "submitterEmail",
   ],
+  secondClockStatuses: [
+    "Pending",
+    "Pending - Concurrence",
+    "Pending - Approval",
+  ],
 };

--- a/services/common/type/waiverAmendment.js
+++ b/services/common/type/waiverAmendment.js
@@ -36,6 +36,11 @@ export const waiverAmendment = {
     "parentId",
     "parentType",
   ],
+  secondClockStatuses: [
+    "Pending",
+    "Pending - Concurrence",
+    "Pending - Approval",
+  ],
 };
 
 export const waiverAmendmentB4 = {

--- a/services/common/type/waiverAppendixK.js
+++ b/services/common/type/waiverAppendixK.js
@@ -22,4 +22,9 @@ export const waiverAppendixK = {
     "waiverAuthority",
     "title",
   ],
+  secondClockStatuses: [
+    "Pending",
+    "Pending - Concurrence",
+    "Pending - Approval",
+  ],
 };

--- a/services/common/type/waiverRenewal.js
+++ b/services/common/type/waiverRenewal.js
@@ -63,4 +63,9 @@ export const waiverRenewalB = {
     tribalConsultation,
     other,
   ],
+  secondClockStatuses: [
+    "Pending",
+    "Pending - Concurrence",
+    "Pending - Approval",
+  ],
 };

--- a/services/ui-src/src/libs/detailLib.ts
+++ b/services/ui-src/src/libs/detailLib.ts
@@ -18,6 +18,7 @@ export type OneMACDetail = {
   showReviewTeam: boolean;
   allowWaiverExtension: boolean;
   attachmentsHeading: string;
+  secondClockStatuses?: string[];
 } & Partial<PackageType>;
 export const blankBox: AttributeDetail = {
   heading: "",

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -149,11 +149,6 @@ export const DetailSection = ({
   setAlertCode: (code: string) => void;
 }) => {
   const { userProfile } = useAppContext() ?? {};
-  const secondClockStatuses = [
-    "Pending",
-    "Pending - Concurrence",
-    "Pending - Approval",
-  ];
 
   const downloadInfoText =
     "Documents available on this page may not reflect the actual documents that were approved by CMS. Please refer to your CMS Point of Contact for the approved documents.";
@@ -194,7 +189,8 @@ export const DetailSection = ({
             </Review>
             {/* Displays 2nd Clock subtitle under status if status is pending (sans Pending - RAI) and
              latestRaiResponseTimestamp is present */}
-            {secondClockStatuses.includes(detail.currentStatus) &&
+            {pageConfig.secondClockStatuses &&
+              pageConfig.secondClockStatuses.includes(detail.currentStatus) &&
               detail?.latestRaiResponseTimestamp && <span>2nd Clock</span>}
             {pageConfig.show90thDayInfo && ninetyDayText !== "N/A" && (
               <Review heading="90th Day">


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-25093
Endpoint: See github-actions bot comment

### Details
HOT FIX: apparently CHIP SPAs do not go into 2nd Clock in the same way that other packages do.

### Changes
- moved the secondClockStatuses array into the configs to be naturally based on type.
- added secondClockStatuses to Medicaid SPA, Initial Waiver, Renewal Waiver, Amendment Waiver, and App K configs.

### Implementation Notes
- Though the 2nd Clock flag is a purely UI concept in Live OneMAC, it does actually apply to the Real Packages and so the team that is creating the entity diagrams will probably want to have this information in the same place as all the other entity details.

### Test Plan
1. Login as a OneMAC CMS User
2. Navigate to Dashboard
3. Locate a [Medicaid SPA, Initial Waiver, Waiver Renewal, Waiver Amendment, App K] package meeting the 2nd Clock criteria per the [24621](https://qmacbis.atlassian.net/browse/OY2-24621)'s AC.
4. Click into the details for that package.
5. Verify the 2nd Clock Status banner is displayed
6. Locate a CHIP SPA package meeting the 2nd Clock criteria per the [24621](https://qmacbis.atlassian.net/browse/OY2-24621)'s AC.
7. Click into the details for that package.
8. Verify the 2nd Clock Status banner is NOT displayed.
