### PR TITLE
Fixes filters by date to include full days

### DIFF
--- a/services/ui-src/src/components/SearchAndFilter.tsx
+++ b/services/ui-src/src/components/SearchAndFilter.tsx
@@ -309,7 +309,13 @@ function DateFilter({
   inThePast,
 }: FilterProps & { inThePast?: boolean }) {
   const onChangeSelection = useCallback(
-    (value) => setFilter(value ?? []),
+    (value) => {
+      value !== null && value.length
+        ? /* Filters come in an array with 2 dates, the earlier always at
+           * index 0, the later date at index 1. */
+          setFilter([startOfDay(value[0]), endOfDay(value[1])])
+        : setFilter([]);
+    },
     [setFilter]
   );
   const ranges: { label: string; value: [Date, Date] }[] = useMemo(


### PR DESCRIPTION
> NOTE ℹ️ 
> This PR goes straight to VAL. A duplicate of this work can be found in #1344 ready to merge to DEV
Story: https://qmacbis.atlassian.net/browse/OY2-25078

### Details

Applies `startOfDay` and `endOfDay` function to the date filter so all results from both days are included.

Dates from the “Past 7 Days” or “Past Month” selections are normalized to “startOfDay” and “endOfDay” values and work as expected, but dates hand-selected by the range picker weren’t. They had the exact time of the selection shown, so effectively filtering for Aug 2-17 when at 10:43am would filter Aug 2 10:43am - Aug 17 10:43am.

```
Current
0: "2023-08-02T14:43:09.640Z"
1: "2023-08-17T14:43:09.640Z"
```
```
Fix
0: "2023-08-02T00:00:00.640Z"
1: "2023-08-17T23:59:59.640Z"
```

### Changes

- Filter value is now checked for length (comes in as an array of 2 date strings in [earliest, latest] order) and if the values are present, the function will normalize the times and return the normalized values

### Implementation Notes

- This is how we handle the same behavior with our "Past 7 Days" type of option

### Test Plan

1. Set any date filter on the Dashboard
2. In dev tools, go to Application
3. Ensure the filter local storage shows the values with normalized time reflecting the fixed values above
