### PR TITLE
OY2 24868: Update NOSOs Admin Package Change Log Language

### DIFF
--- a/services/admin/handlers/createOneMacPackage.js
+++ b/services/admin/handlers/createOneMacPackage.js
@@ -56,9 +56,11 @@ export const createOneMacPackage = async (item) => {
       adminChanges: [
         {
           changeTimestamp: normalizedNow,
-          changeMade: "OneMAC submission created from SEA Tool entry",
-          changeReason:
-            "This is a Not Originally Submitted in OneMAC (NOSO) package that users need to see in OneMAC.",
+          changeMade: `${theID} added to OneMAC. Package not originally submitted in OneMAC.`,
+          changeReason: item?.setChangeReason
+            ? item.setChangeReason
+            : "Per request from CMS, this package was added to OneMAC.",
+          changeType: "Package Added",
         },
       ],
     },
@@ -75,11 +77,14 @@ export const createOneMacPackage = async (item) => {
     try {
       const result = await dynamoDb.get(getParams).promise();
       putParams.Item.attachments = [...result.Item.attachments];
-      putParams.Item.adminChanges.changeMade +=
+      putParams.Item.adminChanges[0].changeMade +=
         " - with attachments copied from " + item.copyAttachmentsFrom;
     } catch (e) {
       console.log("%s error received: ", theID, e);
     }
+  } else {
+    putParams.Item.adminChanges[0].changeMade +=
+      " At this time, the attachments for this package are unavailable in this system. Contact your CPOC to verify the initial submission documents.";
   }
 
   if (item.waiverAuthority)

--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -57432,7 +57432,7 @@
 {
   "clockEndTimestamp": 1698763011776,
   "componentType": "waiverappkrai",
-  "eventTimestamp": 1690987151748,
+  "eventTimestamp": 1673198609000,
   "transmittalNumberWarningMessage": "",
   "currentStatus": "RAI Response Withdraw Enabled",
   "parentId": "MD-22958.R00.02",
@@ -57448,12 +57448,12 @@
   "parentType": "waiverappk",
   "GSI1sk": "MD-22958.R00.02",
   "additionalInformation": "Here is our formal RAI Response",
-  "submissionTimestamp": 1690987011776,
+  "submissionTimestamp": 1673198609000,
   "GSI1pk": "OneMAC#submitwaiverappkrai",
   "adminChanges": [
     {
       "changeReason": "Enabling the RAI Response withdrawal for the automated tests",
-      "changeTimestamp": 1690987151748,
+      "changeTimestamp": 1673198609000,
       "changeMade": "Systemadmin Nightwatch has enabled State package action to withdraw Formal RAI Response"
     }
   ],
@@ -58207,7 +58207,7 @@
 {
   "clockEndTimestamp": 1680725910479,
   "componentType": "waiverrai",
-  "eventTimestamp": 1690986376374,
+  "eventTimestamp": 1676136209000,
   "currentStatus": "RAI Response Withdraw Enabled",
   "parentId": "MD-22204.R00.02",
   "attachments": [
@@ -58228,7 +58228,7 @@
   "adminChanges": [
     {
       "changeReason": "Enable the RAI Response withdraw for the Automated Testing",
-      "changeTimestamp": 1690986376374,
+      "changeTimestamp": 1676136209000,
       "changeMade": "Systemadmin Nightwatch has enabled State package action to withdraw Formal RAI Response"
     }
   ],
@@ -59535,5 +59535,77 @@
   },
   "pk": "MD-2200.R00.10",
   "RO_ANALYST": null
-}
+},
+{
+  "pk": "MD-8676.R00.05",
+  "sk": "OneMAC#1673529269000",
+  "additionalInformation": "Testing an App K submission",
+  "attachments": [
+   {
+    "contentType": "image/png",
+    "filename": "Screenshot 2023-03-31 at 4.46.08 PM.png",
+    "s3Key": "1692650463345/Screenshot 2023-03-31 at 4.46.08 PM.png",
+    "title": "1915(c) Appendix K Amendment Waiver Template",
+    "url": "https://uploads-oy2-23552-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3Aa18bf80a-e96a-4193-811a-419200fc8665/1692650463345/Screenshot%202023-03-31%20at%204.46.08%20PM.png"
+   }
+  ],
+  "clockEndTimestamp": 1700430064582,
+  "componentId": "MD-8676.R00.05",
+  "componentType": "waiverappk",
+  "currentStatus": "Submitted",
+  "eventTimestamp": 1673529269000,
+  "GSI1pk": "OneMAC#submitwaiverappk",
+  "GSI1sk": "MD-8676.R00.05",
+  "proposedEffectiveDate": "2023-09-04",
+  "submissionTimestamp": 1673529269000,
+  "submitterEmail": "statesubmitter@nightwatch.test",
+  "submitterName": "StateSubmitter Nightwatch",
+  "territory": "MD",
+  "title": "Testing the App K submissions",
+  "transmittalNumberWarningMessage": "",
+  "waiverAuthority": "1915(c)"
+ },
+ {
+  "pk": "MD-8676.R00.05",
+  "sk": "Package",
+  "additionalInformation": "Testing an App K submission",
+  "adminChanges": [
+  ],
+  "attachments": [
+   {
+    "contentType": "image/png",
+    "filename": "Screenshot 2023-03-31 at 4.46.08 PM.png",
+    "s3Key": "1692650463345/Screenshot 2023-03-31 at 4.46.08 PM.png",
+    "title": "1915(c) Appendix K Amendment Waiver Template",
+    "url": "https://uploads-oy2-23552-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3Aa18bf80a-e96a-4193-811a-419200fc8665/1692650463345/Screenshot%202023-03-31%20at%204.46.08%20PM.png"
+   }
+  ],
+  "clockEndTimestamp": 1700430064582,
+  "componentId": "MD-8676.R00.05",
+  "componentType": "waiverappk",
+  "cpocName": "-- --",
+  "currentStatus": "Submitted",
+  "description": "-- --",
+  "GSI1pk": "OneMAC#waiver",
+  "GSI1sk": "MD-8676.R00.05",
+  "lastActivityTimestamp": 1673529269000,
+  "lastEventTimestamp": 1673529269000,
+  "proposedEffectiveDate": "2023-09-04",
+  "raiResponses": [
+  ],
+  "reviewTeam": [
+  ],
+  "reviewTeamEmailList": [
+  ],
+  "subject": "-- --",
+  "submissionTimestamp": 1673529269000,
+  "submitterEmail": "statesubmitter@nightwatch.test",
+  "submitterName": "StateSubmitter Nightwatch",
+  "title": "Testing the App K submissions",
+  "waiverAuthority": "1915(c)",
+  "waiverExtensions": [
+  ],
+  "withdrawalRequests": [
+  ]
+ }
 ]

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -291,8 +291,9 @@ export const DetailSection = ({
                     contentClassName="accordion-content"
                     heading={
                       "Submitted on " +
-                      formatDate(adminChange.changeTimestamp) +
-                      " - Manual Update"
+                        formatDate(adminChange.changeTimestamp) +
+                        " - " +
+                        adminChange?.changeType ?? "Manual Update"
                     }
                     headingLevel="6"
                     id={"admin_change_" + index + "_caret"}

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -291,9 +291,11 @@ export const DetailSection = ({
                     contentClassName="accordion-content"
                     heading={
                       "Submitted on " +
-                        formatDate(adminChange.changeTimestamp) +
-                        " - " +
-                        adminChange?.changeType ?? "Manual Update"
+                      formatDate(adminChange.changeTimestamp) +
+                      " - " +
+                      adminChange.changeType
+                        ? adminChange.changeType
+                        : "Manual Update"
                     }
                     headingLevel="6"
                     id={"admin_change_" + index + "_caret"}

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -293,9 +293,9 @@ export const DetailSection = ({
                       "Submitted on " +
                       formatDate(adminChange.changeTimestamp) +
                       " - " +
-                      adminChange.changeType
+                      (adminChange.changeType
                         ? adminChange.changeType
-                        : "Manual Update"
+                        : "Manual Update")
                     }
                     headingLevel="6"
                     id={"admin_change_" + index + "_caret"}


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24868
Endpoint: See github-actions bot comment

### Details
As a OneMAC user, I want different language to be considered for the NOSO Change Made and Change Reason fields on the Administrative Package Change log. 

### Changes
- updated createOneMACPackage to use the new text format for NOSO packages
- added event variables to to createOneMACPackage to allow for custom updates/changes
- fixed some seed data 
- Updated the Admin Change Header to be able to tell a "Package Added" from a "Manual Update"

### Test Plan
1. Login to the AWS console 
2. Identify a SEA Tool event who is not represented in OneMAC
3. use the createOneMACPackage lambda to create that package as a NOSO in OneMAC
4. Login to OneMAC
5. Navigate to the new NOSO package
6. Verify the header and texts are as described in the story AC.
Extra Credit: Add NOSOs that use the attachment copying feature and setChangeReason features... :) 
