### PR TITLE
allow package withdraw for withdraw rai response enabled status

### DIFF
--- a/services/app-api/utils/actionDelegate.js
+++ b/services/app-api/utils/actionDelegate.js
@@ -28,7 +28,10 @@ function getDefaultActions(
       break;
     case Workflow.ONEMAC_STATUS.WITHDRAW_RAI_ENABLED:
       if (userRole.canAccessForms)
-        actions.push(Workflow.PACKAGE_ACTION.WITHDRAW_RAI);
+        actions.push(
+          Workflow.PACKAGE_ACTION.WITHDRAW,
+          Workflow.PACKAGE_ACTION.WITHDRAW_RAI
+        );
       break;
   }
   return actions;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-25095
Endpoint: See github-actions bot comment

### Details

Allow withdraw package action for packages that are in RAI Response Withdraw Enabled status
### Changes

- Modified actionDelegate to add action for WITHDRAW_RAI_ENABLED status

### Implementation Notes

- Not anything in ACs but I noticed when looking at statuses that there is no logic in the action delegate for WITHDRAW_RAI_REQUESTED

### Test Plan

1. Login as state user
2. Locate a package in RAI Response Withdraw Enabled status
3. Verify the package has "Withdraw Package" action from package list and details page
