### PR TITLE
Update additional info for Enable RAI Withdraw form

### DIFF
--- a/services/ui-src/src/libs/formLib.tsx
+++ b/services/ui-src/src/libs/formLib.tsx
@@ -24,7 +24,7 @@ export type OneMACFormConfig = {
   attachmentsTitle?: string;
   attachmentIntroJSX: JSX.Element;
   addlInfoTitle?: string;
-  addlInfoText?: string;
+  addlInfoText?: string | React.ReactNode;
   addlInfoRequired?: boolean;
   requireUploadOrAdditionalInformation?: boolean;
   landingPage: string;

--- a/services/ui-src/src/page/enable-rai-withdraw/EnableRaiWithdrawForm.tsx
+++ b/services/ui-src/src/page/enable-rai-withdraw/EnableRaiWithdrawForm.tsx
@@ -22,7 +22,12 @@ export const enableRaiWithdrawFormInfo: OneMACFormConfig = {
     </p>
   ),
   addlInfoTitle: "Change Reason",
-  addlInfoText: "Please be descriptive about why this action is being enabled.",
+  addlInfoText: (
+    <p>
+      Please be descriptive about why this action is being enabled.{" "}
+      <b>Information entered will be visible to both CMS and State users.</b>
+    </p>
+  ) as React.ReactNode,
   addlInfoRequired: true,
   landingPage: ONEMAC_ROUTES.PACKAGE_LIST,
   submitInstructionsJSX: <></>,

--- a/tests/cypress/cypress/e2e/common/steps.js
+++ b/tests/cypress/cypress/e2e/common/steps.js
@@ -3079,7 +3079,7 @@ Then("verify the CPOC has a value displayed in the details section", () => {
   OneMacPackageDetailsPage.verifyCPOCNameValueExists();
 });
 Then("verify CPOC is not visible in the details section", () => {
-  OneMacPackageDetailsPage.verifyCPOCNameDoesNotExists();
+  OneMacPackageDetailsPage.verifyCPOCNameDoesNotExist();
 });
 Then("verify there is a Review Team SRT header in the details section", () => {
   OneMacPackageDetailsPage.verifyReviewTeamSRTHeaderExists();

--- a/tests/cypress/support/pages/oneMacPackageDetailsPage.js
+++ b/tests/cypress/support/pages/oneMacPackageDetailsPage.js
@@ -442,7 +442,7 @@ export class oneMacPackageDetailsPage {
       .next("div")
       .contains(/^(?!\s*$).+/);
   }
-  verifyCPOCNameDoesNotExists() {
+  verifyCPOCNameDoesNotExist() {
     cy.xpath(cPOCNameHeader).should("not.exist");
   }
   verifyReviewTeamSRTHeaderExists() {
@@ -455,9 +455,6 @@ export class oneMacPackageDetailsPage {
   }
   verifyReviewTeamSRTDoesNotExists() {
     cy.xpath(reviewTeamSRTHeader).should("not.exist");
-  }
-  verifyCPOCNameDoesNotExists() {
-    cy.xpath(cPOCNameHeader).should("not.exist");
   }
   verifyFormalRAIResponseCaretBtnExists() {
     cy.xpath(formalRAIResponseCaretBtn).should("be.visible");

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -97,13 +97,13 @@ const underReviewCheckBox =
   "//label[contains(@for,'checkbox_packageStatus-Under Review')]";
 //Element is Xpath use cy.xpath instead of cy.get
 const withdrawalRequestedCheckBox =
-  "//label[contains(@for,'checkbox_packageStatus-Withdrawal Requested']";
+  "//label[contains(@for,'checkbox_packageStatus-Withdrawal Requested')]";
 //Element is Xpath use cy.xpath instead of cy.get
 const raiResponseWithdrawalRequestedCheckBox =
-  "//label[contains(@for,'checkbox_packageStatus-Formal RAI Response - Withdrawal Requested']";
+  "//label[contains(@for,'checkbox_packageStatus-Formal RAI Response - Withdrawal Requested')]";
 //Element is Xpath use cy.xpath instead of cy.get
 const raiResponseWithdrawEnabledCheckBox =
-  "//label[contains(@for,'checkbox_packageStatus-RAI Response Withdraw Enabled']";
+  "//label[contains(@for,'checkbox_packageStatus-RAI Response Withdraw Enabled')]";
 //Element is Xpath use cy.xpath instead of cy.get
 const terminatedCheckBox =
   "//label[contains(@for,'checkbox_packageStatus-Waiver Terminated')]";


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-25312

### Details

Updates the additional info text for Formal RAI Response Withdraw form

### Changes

- `TextArea.hint` allows for a `ReactNode` to be passed in so I expanded the `OneMACFormConfig.addlInfoText` property to use the same type

### Implementation Notes

- N/A

### Test Plan

1. Locate a package with Enable Withdraw Formal RAI Response action available
2. Click the action and view the subsequent form page
3. Ensure the text matches spelling and formatting of the AC
