### PR TITLE
Add filter count to filter button

### DIFF
--- a/services/ui-src/src/components/SearchAndFilter.tsx
+++ b/services/ui-src/src/components/SearchAndFilter.tsx
@@ -487,6 +487,8 @@ function FilterPane<V extends {}>({
   setAllFilters,
 }: FilterPaneProps<V>) {
   const [showFilters, toggleShowFilters] = useToggle(false);
+  const { state: filterChips } = useFilterChipContext();
+  const filterCount = useMemo(() => filterChips.length, [filterChips]);
   const { dispatch: updateFilterChips } = useFilterChipContext();
   const onResetFilters = useCallback(() => {
     // Resets filter chips state to no chips showing
@@ -524,7 +526,7 @@ function FilterPane<V extends {}>({
 
   return (
     <>
-      <Button onClick={toggleShowFilters}>Filter</Button>
+      <Button onClick={toggleShowFilters}>Filter ({filterCount})</Button>
 
       {transitionFilterPane((style, showFilters) =>
         showFilters

--- a/services/ui-src/src/components/SearchAndFilter.tsx
+++ b/services/ui-src/src/components/SearchAndFilter.tsx
@@ -488,7 +488,10 @@ function FilterPane<V extends {}>({
 }: FilterPaneProps<V>) {
   const [showFilters, toggleShowFilters] = useToggle(false);
   const { state: filterChips } = useFilterChipContext();
-  const filterCount = useMemo(() => filterChips.length, [filterChips]);
+  const filterCount = useMemo(
+    () => filterChips.filter((chipVal) => chipVal.label !== null).length,
+    [filterChips]
+  );
   const { dispatch: updateFilterChips } = useFilterChipContext();
   const onResetFilters = useCallback(() => {
     // Resets filter chips state to no chips showing


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24852

### Details

Adds the count of filters to the button that opens the filter pane.

### Changes

- `FilterPane` hooks into the `FilterChipContext` to pull the array and provide the count
- Filter button shows count

### Implementation Notes

- Developer focused info that may affect future work

### Test Plan

1. Log in as any user with dashboard access
2. Add filters via the filter ui 
3. Ensure the Filter button updates with the count of the applied filters
