### PR TITLE
Oy2 23799 - add emails for subsequent submissions

### DIFF
--- a/services/app-api/email/CMSSubsequentSubmissionNotice.js
+++ b/services/app-api/email/CMSSubsequentSubmissionNotice.js
@@ -1,0 +1,50 @@
+import { formatPackageDetails } from "./formatPackageDetails.js";
+import { getCPOCandSRTEmailAddresses } from "../utils/getCpocAndSrtEmail.js";
+
+/**
+ * Package Submission email to CMS
+ * @param {Object} data from the package.
+ * @returns {Object} email parameters in generic format.
+ */
+export const CMSSubsequentSubmissionNotice = async (data, config) => {
+  const CMSEmailItem = await getCPOCandSRTEmailAddresses(data.componentId);
+
+  const ToAddresses = CMSEmailItem.reviewTeamEmailList
+    ? [...CMSEmailItem.reviewTeamEmailList]
+    : [];
+
+  CMSEmailItem?.cpocEmail && ToAddresses.push(CMSEmailItem.cpocEmail);
+
+  return {
+    ToAddresses: ToAddresses,
+    CcAddresses: [],
+    Subject: `Subsequent Documentation for ${config.typeLabel} ${data.componentId}`,
+    HTML: `
+        <p>The OneMAC Submission Portal received subsequent documentation materials for this ${
+          config.typeLabel
+        }:</p>
+        <ul>
+            <li>
+            The submission can be accessed in the OneMAC application, which you can
+            find at <a href="${
+              process.env.applicationEndpoint
+            }/dashboard">this link</a>.
+            </li>
+            <li>
+            If you are not already logged in, please click the "Login" link at the
+            top of the page and log in using your Enterprise User Administration
+            (EUA) credentials.
+            </li>
+            <li>
+            After you have logged in, you will be taken to the OneMAC application.
+            The submission will be listed on the dashboard page, and you can view
+            its details by clicking on its ID number.
+            </li>
+        </ul>
+        ${formatPackageDetails(data, config)}
+        <br>
+        <p>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
+        <p>Thank you!</p>
+        `,
+  };
+};

--- a/services/app-api/email/CMSSubsequentSubmissionNotice.test.js
+++ b/services/app-api/email/CMSSubsequentSubmissionNotice.test.js
@@ -1,0 +1,26 @@
+import { CMSSubsequentSubmissionNotice } from "./CMSSubsequentSubmissionNotice";
+
+it("builds the CMS Submission Notice Email", async () => {
+  const testData = {
+    submitterName: "name",
+    componentId: "MI-11-1111-22",
+    proposedEffectiveDate: "2022-06-07",
+  };
+  const testConfig = {
+    typeLabel: "Test Type",
+  };
+  const warnings = [];
+
+  const response2 = await CMSSubsequentSubmissionNotice(testData, testConfig);
+
+  expect(response2.Subject).toBe(
+    "Subsequent Documentation for " +
+      testConfig.typeLabel +
+      " " +
+      testData.componentId
+  );
+
+  expect(response2.HTML.includes(testData.componentId)).toBe(true);
+  expect(response2.HTML.includes(process.env.applicationEndpoint)).toBe(true);
+  expect(response2.HTML.length).toBe(1293);
+});

--- a/services/app-api/email/CMSWithdrawRaiNotice.js
+++ b/services/app-api/email/CMSWithdrawRaiNotice.js
@@ -1,27 +1,6 @@
-import dynamoDb from "../libs/dynamodb-lib";
-
 import { ONEMAC_TYPE } from "cmscommonlib/workflow.js";
 import { formatPackageDetails } from "./formatPackageDetails.js";
-
-export const getCPOCandSRTEmailAddresses = async (packageId) => {
-  let returnObj = {};
-  const qParams = {
-    TableName: process.env.oneMacTableName,
-    Key: {
-      pk: `${packageId}`,
-      sk: "Package",
-    },
-    ProjectionExpression: "cpocEmail, reviewTeamEmailList",
-  };
-  try {
-    const packageItem = await dynamoDb.get(qParams);
-
-    returnObj = packageItem.Item;
-  } catch (e) {
-    console.log("query error: ", e.message);
-  }
-  return returnObj;
-};
+import { getCPOCandSRTEmailAddresses } from "../utils/getCpocAndSrtEmail";
 
 /**
  * RAI Response withdrawal email to CMS

--- a/services/app-api/email/CMSWithdrawalRaiNotice.test.js
+++ b/services/app-api/email/CMSWithdrawalRaiNotice.test.js
@@ -1,10 +1,8 @@
 import dynamoDb from "../libs/dynamodb-lib";
 import { ONEMAC_TYPE } from "cmscommonlib/workflow.js";
 
-import {
-  CMSWithdrawRaiNotice,
-  getCPOCandSRTEmailAddresses,
-} from "./CMSWithdrawRaiNotice";
+import { CMSWithdrawRaiNotice } from "./CMSWithdrawRaiNotice";
+import { getCPOCandSRTEmailAddresses } from "../utils/getCpocAndSrtEmail";
 
 jest.mock("../libs/dynamodb-lib");
 

--- a/services/app-api/email/stateSubsequentSubmissionReceipt.js
+++ b/services/app-api/email/stateSubsequentSubmissionReceipt.js
@@ -1,0 +1,26 @@
+import { DateTime } from "luxon";
+
+import { formatPackageDetails } from "./formatPackageDetails.js";
+
+/**
+ * Package submission receipt email to state user(s)
+ * @param {Object} data from the package.
+ * @returns {Object} email parameters in generic format.
+ */
+export const stateSubsequentSubmissionReceipt = (data, config) => {
+  data.attachments = {}; //remove attachments because we dont want them listed in the state email
+
+  return {
+    ToAddresses: [`${data.submitterName} <${data.submitterEmail}>`],
+    CcAddresses: [],
+    Subject: `Subsequent Documentation for ${config.typeLabel} ${data.componentId}`,
+    HTML: `
+    <p>	This is confirmation that you submitted ${
+      config.typeLabel
+    } materials to CMS for review:</p>
+    ${formatPackageDetails(data, config)}
+    <br>
+    <p>If you have questions or did not expect this email, please contact <a href="mailto:spa@cms.hhs.gov">SPA@CMS.HHS.gov</a>.</p>
+    <p>Thank you!</p>`,
+  };
+};

--- a/services/app-api/email/stateSubsequentSubmissionReceipt.js
+++ b/services/app-api/email/stateSubsequentSubmissionReceipt.js
@@ -1,5 +1,3 @@
-import { DateTime } from "luxon";
-
 import { formatPackageDetails } from "./formatPackageDetails.js";
 
 /**

--- a/services/app-api/email/stateSubsequentSubmissionReceipt.test.js
+++ b/services/app-api/email/stateSubsequentSubmissionReceipt.test.js
@@ -1,0 +1,19 @@
+import { stateSubsequentSubmissionReceipt } from "./stateSubsequentSubmissionReceipt";
+
+it("builds the State Submission Receipt Email", async () => {
+  const testData = {
+    submitterName: "name",
+    submitterEmail: "theemail@email.com",
+    componentId: "MI-11-1111-22",
+    clockEndTimestamp: 1631626754502,
+  };
+  const testConfig = {
+    typeLabel: "Test Type",
+  };
+  try {
+    const response2 = stateSubsequentSubmissionReceipt(testData, testConfig);
+    expect(response2.HTML.length).toBe(999);
+  } catch (e) {
+    console.log("reeived error: ", e);
+  }
+});

--- a/services/app-api/form/defaultFormConfig.js
+++ b/services/app-api/form/defaultFormConfig.js
@@ -3,6 +3,8 @@ import Joi from "joi";
 import { RESPONSE_CODE, Workflow } from "cmscommonlib";
 import { CMSWithdrawalNotice } from "../email/CMSWithdrawalNotice";
 import { stateWithdrawalReceipt } from "../email/stateWithdrawalReceipt";
+import { CMSSubsequentSubmissionNotice } from "../email/CMSSubsequentSubmissionNotice";
+import { stateSubsequentSubmissionReceipt } from "../email/stateSubsequentSubmissionReceipt";
 
 export const defaultFormConfig = {
   CMSToAddresses: [process.env.reviewerEmail, process.env.testingEmail].filter(
@@ -38,6 +40,8 @@ export const defaultSubsequentSubmissionConfig = {
   newStatus: null, //use parent's current package status
   successResponseCode:
     RESPONSE_CODE.SUCCESSFULLY_SUBMITTED_SUBSEQUENT_SUBMISSION,
+  buildCMSNotice: CMSSubsequentSubmissionNotice,
+  buildStateReceipt: stateSubsequentSubmissionReceipt,
   appendToSchema: {
     ...defaultSubsequentSubmissionSchema,
   },

--- a/services/app-api/utils/getCpocAndSrtEmail.js
+++ b/services/app-api/utils/getCpocAndSrtEmail.js
@@ -1,0 +1,21 @@
+import dynamoDb from "../libs/dynamodb-lib";
+
+export const getCPOCandSRTEmailAddresses = async (packageId) => {
+  let returnObj = {};
+  const qParams = {
+    TableName: process.env.oneMacTableName,
+    Key: {
+      pk: `${packageId}`,
+      sk: "Package",
+    },
+    ProjectionExpression: "cpocEmail, reviewTeamEmailList",
+  };
+  try {
+    const packageItem = await dynamoDb.get(qParams);
+
+    returnObj = packageItem.Item;
+  } catch (e) {
+    console.log("query error: ", e.message);
+  }
+  return returnObj;
+};


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-23799
Endpoint: https://dq6gyijpx3ouv.cloudfront.net/

### Details

Add state and cms emails to subsequent submission workflow

### Changes

- Extracted SRT and CPOC email collection from withdraw rai email to common method so that it could also be used in subsequent submission emails
- added state and cms email templates + tests
- added email templates to default subsequent submission config


### Implementation Notes

- I followed ACs and put the only recipients of the CMS email to be CPOC and SRTs but worry that there could be a package without a CPOC or SRT from SeaTool? In which case the email would fail.

### Test Plan

1. Log in as state submitter
2. Locate package of any type in Under Review status
3. Submit subsequent submission documents
4. Verify emails
