### PR TITLE
OY2-25114 - subsequent submission reverse chrono

### DIFF
--- a/services/app-api/utils/actionDelegate.test.js
+++ b/services/app-api/utils/actionDelegate.test.js
@@ -113,6 +113,9 @@ describe("getActionsForPackage", () => {
       formSource
     );
 
-    expect(actions).toEqual(["Withdraw Package"]);
+    expect(actions).toEqual([
+      "Withdraw Package",
+      "Upload Subsequent Documents",
+    ]);
   });
 });

--- a/services/one-stream/lib/default-lib.js
+++ b/services/one-stream/lib/default-lib.js
@@ -3,3 +3,4 @@ export const initialSubmissionType = "Initial Package";
 export const packageType = "Package";
 export const submitAction = "Submitted";
 export const withdrawalRequestedAction = "Withdrawal Requested";
+export const subsequentSubmissionType = "Subsequent Documentation Uploaded";

--- a/services/one-stream/package/buildChipSpa.js
+++ b/services/one-stream/package/buildChipSpa.js
@@ -5,6 +5,7 @@ import {
   packageType,
   submitAction,
   withdrawalRequestedAction,
+  subsequentSubmissionType,
 } from "../lib/default-lib";
 import { buildAnyPackage } from "./buildAnyPackage";
 
@@ -12,6 +13,7 @@ const chipSPABuildConfig = {
   ...chipSPA,
   eventTypeMap: {
     submitchipspa: initialSubmissionType,
+    submitchipspasubsequent: subsequentSubmissionType,
     submitchipsparai: formalRAIResponseType,
     submitchipspawithdraw: packageType,
     submitrairesponsewithdraw: formalRAIResponseType,

--- a/services/one-stream/package/buildInitialWaiver.js
+++ b/services/one-stream/package/buildInitialWaiver.js
@@ -1,6 +1,7 @@
 import { initialWaiver } from "cmscommonlib";
 import {
   initialSubmissionType,
+  subsequentSubmissionType,
   formalRAIResponseType,
   packageType,
   submitAction,
@@ -12,6 +13,7 @@ const initialWaiverBuildConfig = {
   ...initialWaiver,
   eventTypeMap: {
     submitwaivernew: initialSubmissionType,
+    submitwaivernewsubsequent: subsequentSubmissionType,
     submitwaiverrai: formalRAIResponseType,
     submitwaivernewwithdraw: packageType,
     submitrairesponsewithdraw: formalRAIResponseType,

--- a/services/one-stream/package/buildMedicaidSpa.js
+++ b/services/one-stream/package/buildMedicaidSpa.js
@@ -1,6 +1,7 @@
 import { medicaidSPA } from "cmscommonlib";
 import {
   initialSubmissionType,
+  subsequentSubmissionType,
   formalRAIResponseType,
   packageType,
   submitAction,
@@ -12,6 +13,7 @@ const medicaidSPABuildConfig = {
   ...medicaidSPA,
   eventTypeMap: {
     submitmedicaidspa: initialSubmissionType,
+    submitmedicaidspasubsequent: subsequentSubmissionType,
     submitmedicaidsparai: formalRAIResponseType,
     submitmedicaidspawithdraw: packageType,
     submitrairesponsewithdraw: formalRAIResponseType,

--- a/services/one-stream/package/buildWaiverAmendment.js
+++ b/services/one-stream/package/buildWaiverAmendment.js
@@ -5,6 +5,7 @@ import {
   packageType,
   submitAction,
   withdrawalRequestedAction,
+  subsequentSubmissionType,
 } from "../lib/default-lib";
 import { buildAnyPackage } from "./buildAnyPackage";
 
@@ -12,6 +13,7 @@ const waiverAmendmentBuildConfig = {
   ...waiverAmendment,
   eventTypeMap: {
     submitwaiveramendment: initialSubmissionType,
+    submitwaiveramendmentsubsequent: subsequentSubmissionType,
     submitwaiverrai: formalRAIResponseType,
     submitwaiveramendmentwithdraw: packageType,
     submitrairesponsewithdraw: formalRAIResponseType,

--- a/services/one-stream/package/buildWaiverAppendixK.js
+++ b/services/one-stream/package/buildWaiverAppendixK.js
@@ -5,6 +5,7 @@ import {
   packageType,
   submitAction,
   withdrawalRequestedAction,
+  subsequentSubmissionType,
 } from "../lib/default-lib";
 import { buildAnyPackage } from "./buildAnyPackage";
 
@@ -12,6 +13,7 @@ const waiverAppendixKBuildConfig = {
   ...waiverAppendixK,
   eventTypeMap: {
     submitwaiverappk: initialSubmissionType,
+    submitwaiverappksubsequent: subsequentSubmissionType,
     submitwaiverappkrai: formalRAIResponseType,
     submitwaiverappkwithdraw: packageType,
     submitrairesponsewithdraw: formalRAIResponseType,

--- a/services/one-stream/package/buildWaiverRenewal.js
+++ b/services/one-stream/package/buildWaiverRenewal.js
@@ -5,6 +5,7 @@ import {
   packageType,
   submitAction,
   withdrawalRequestedAction,
+  subsequentSubmissionType,
 } from "../lib/default-lib";
 import { buildAnyPackage } from "./buildAnyPackage";
 
@@ -12,6 +13,7 @@ const waiverRenewalBuildConfig = {
   ...waiverRenewal,
   eventTypeMap: {
     submitwaiverrenewal: initialSubmissionType,
+    submitwaiverrenewalsubsequent: subsequentSubmissionType,
     submitwaiverrai: formalRAIResponseType,
     submitwaiverrenewalwithdraw: packageType,
     submitrairesponsewithdraw: formalRAIResponseType,

--- a/tests/cypress/cypress/e2e/Subsequent_Submission_1915b_Amendment_Waiver.spec.feature
+++ b/tests/cypress/cypress/e2e/Subsequent_Submission_1915b_Amendment_Waiver.spec.feature
@@ -38,7 +38,7 @@ Feature: Subsequent Submission 1915b Waiver Amendment
         Then click form cancel button
         Then click Leave Anyway form button
         Then verify the package details page is visible
-        
+
         Scenario: Screen Enhance - Subsequent Documents from the package dashboard
         Then click the actions button in row one
         Then verify Upload Subsequent Documents action exists
@@ -93,3 +93,5 @@ Feature: Subsequent Submission 1915b Waiver Amendment
         Then click the yes, submit modal button
         Then verify the package details page is visible
         Then verify the success message is "Attachments have been successfully submitted"
+        Then verify the Subsequent Documentation Uploaded caret button exists
+        Then verify the Subsequent Documentation download all button exists

--- a/tests/cypress/cypress/e2e/Subsequent_Submission_1915c_Appendix_K.spec.feature
+++ b/tests/cypress/cypress/e2e/Subsequent_Submission_1915c_Appendix_K.spec.feature
@@ -92,3 +92,5 @@ Feature: Subsequent Submission 1915c App K Waiver
         Then click the yes, submit modal button
         Then verify the package details page is visible
         Then verify the success message is "Attachments have been successfully submitted"
+        Then verify the Subsequent Documentation Uploaded caret button exists
+        Then verify the Subsequent Documentation download all button exists

--- a/tests/cypress/cypress/e2e/Subsequent_Submission_CHIP_Spa.spec.feature
+++ b/tests/cypress/cypress/e2e/Subsequent_Submission_CHIP_Spa.spec.feature
@@ -92,3 +92,5 @@ Feature: CHIP SPA State Details View - Card View with Actions
         Then click the yes, submit modal button
         Then verify the package details page is visible
         Then verify the success message is "Attachments have been successfully submitted"
+        Then verify the Subsequent Documentation Uploaded caret button exists
+        Then verify the Subsequent Documentation download all button exists

--- a/tests/cypress/cypress/e2e/Subsequent_Submission_Initial_Waiver.spec.feature
+++ b/tests/cypress/cypress/e2e/Subsequent_Submission_Initial_Waiver.spec.feature
@@ -93,4 +93,6 @@ Feature: Subsequent Submission 1915b Initial Waiver
         Then click the yes, submit modal button
         Then verify the package details page is visible
         Then verify the success message is "Attachments have been successfully submitted"
+        Then verify the Subsequent Documentation Uploaded caret button exists
+        Then verify the Subsequent Documentation download all button exists
         

--- a/tests/cypress/cypress/e2e/Subsequent_Submission_Medicaid_Spa.spec.feature
+++ b/tests/cypress/cypress/e2e/Subsequent_Submission_Medicaid_Spa.spec.feature
@@ -95,3 +95,5 @@ Feature: Medicaid SPA State Details View - Card View with Actions
         Then click the yes, submit modal button
         Then verify the package details page is visible
         Then verify the success message is "Attachments have been successfully submitted"
+        Then verify the Subsequent Documentation Uploaded caret button exists
+        Then verify the Subsequent Documentation download all button exists

--- a/tests/cypress/cypress/e2e/Subsequent_Submission_Renewal_Waiver.spec.feature
+++ b/tests/cypress/cypress/e2e/Subsequent_Submission_Renewal_Waiver.spec.feature
@@ -93,3 +93,5 @@ Feature: Subsequent Submission 1915b Renewal Waiver
         Then click the yes, submit modal button
         Then verify the package details page is visible
         Then verify the success message is "Attachments have been successfully submitted"
+        Then verify the Subsequent Documentation Uploaded caret button exists
+        Then verify the Subsequent Documentation download all button exists

--- a/tests/cypress/cypress/e2e/common/steps.js
+++ b/tests/cypress/cypress/e2e/common/steps.js
@@ -3221,3 +3221,15 @@ Then("verify the Withdrawal Requested download all button exists", () => {
 Then("click the Withdrawal Requested download all button", () => {
   OneMacPackageDetailsPage.clickWithdrawalRequestedDownloadAllBtn();
 });
+Then("verify the Subsequent Documentation Uploaded caret button exists", () => {
+  OneMacPackageDetailsPage.verifySubsequentSubmissionCaretBtnExists();
+});
+Then("click the Subsequent Documentation Uploaded caret button", () => {
+  OneMacPackageDetailsPage.clickSubsequentSubmissionCaretBtn();
+});
+Then("verify the Subsequent Documentation download all button exists", () => {
+  OneMacPackageDetailsPage.verifySubsequentSubmissionDownloadAllBtnExists();
+});
+Then("click the Subsequent Documentation download all button", () => {
+  OneMacPackageDetailsPage.clickSubsequentSubmissionDownloadAllBtn();
+});

--- a/tests/cypress/support/pages/oneMacPackageDetailsPage.js
+++ b/tests/cypress/support/pages/oneMacPackageDetailsPage.js
@@ -85,6 +85,10 @@ const withdrawalRequestedCaretBtn =
   '//h2//button[contains(@id,"Package0_caret-button")]';
 const withdrawalRequestedDownloadAllBtn =
   '//button[contains(@id,"dl_Package-0")]';
+const subsequentSubmissionCaretBtn =
+  '//h2//button[contains(@id,"Subsequent Documentation Uploaded")]';
+const subsequentSubmissionDownloadAllBtn =
+  '//button[contains(@id,"dl_Subsequent Documentation Uploaded")]';
 
 export class oneMacPackageDetailsPage {
   verifyPackageDetailsPageIsVisible() {
@@ -576,6 +580,19 @@ export class oneMacPackageDetailsPage {
   }
   clickWithdrawalRequestedDownloadAllBtn() {
     cy.xpath(withdrawalRequestedDownloadAllBtn).click();
+  }
+  verifySubsequentSubmissionCaretBtnExists() {
+    cy.xpath(subsequentSubmissionCaretBtn).should("be.visible");
+  }
+  clickSubsequentSubmissionCaretBtn() {
+    cy.xpath(subsequentSubmissionCaretBtn).click();
+  }
+
+  verifySubsequentSubmissionDownloadAllBtnExists() {
+    cy.xpath(subsequentSubmissionDownloadAllBtn).should("be.visible");
+  }
+  clickSubsequentSubmissionDownloadAllBtn() {
+    cy.xpath(subsequentSubmissionDownloadAllBtn).click();
   }
 }
 export default oneMacPackageDetailsPage;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-25114
Endpoint: https://d26hd3mhliyq1l.cloudfront.net/

### Details

Add subsequent submission events to the details page in reverse chrono style.

### Changes

- Added subsequentSubmissionType to default-lib
- Added subsequentSubmissionType mapping to each package build config eventTypeMap

### Test Plan

1. Login as state user
2. Locate package in Under Review status
3. Perform Subsequent Submission action
4. Verify package detail shows subsequent submission in reverse chrono with the new subsequent submission event expanded
5. Verify contents of subsequent submission details against AC

NOTE: I noticed that some of this implementation might need to change after merge of oy2-25156 -> develop -> sub-sub