### PR TITLE
PI1.4 26064: CMS RAI Response Withdrawal enablement update

### DIFF
--- a/services/ui-src/src/libs/formLib.tsx
+++ b/services/ui-src/src/libs/formLib.tsx
@@ -26,6 +26,7 @@ export type OneMACFormConfig = {
   addlInfoTitle?: string;
   addlInfoText?: string | React.ReactNode;
   addlInfoRequired?: boolean;
+  noText?: boolean;
   requireUploadOrAdditionalInformation?: boolean;
   landingPage: string;
   confirmSubmit?: ConfirmSubmitType;

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -539,40 +539,44 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
               ></FileUploader>
             </>
           )}
-          <TextField
-            name="additionalInformation"
-            labelClassName={
-              formConfig.addlInfoRequired ? "addl-info-required" : ""
-            }
-            label={formConfig.addlInfoTitle}
-            labelId="additional-information-label"
-            id="additional-information"
-            hint={
-              formConfig.addlInfoText ??
-              "Add anything else that you would like to share with CMS."
-            }
-            disabled={isSubmitting}
-            fieldClassName="summary-field required"
-            multiline
-            onChange={(e) => {
-              handleInputChange(e);
-            }}
-            value={oneMacFormData.additionalInformation}
-            maxLength={config.MAX_ADDITIONAL_INFO_LENGTH}
-            aria-describedby="character-count"
-            aria-live="off"
-            aria-multiline={true}
-          ></TextField>
-          <span
-            tabIndex={0}
-            id="character-count"
-            aria-label="character-count"
-            aria-live="polite"
-          >
-            {`${
-              4000 - oneMacFormData.additionalInformation.length
-            } characters remaining`}
-          </span>
+          {!formConfig?.noText && (
+            <>
+              <TextField
+                name="additionalInformation"
+                labelClassName={
+                  formConfig.addlInfoRequired ? "addl-info-required" : ""
+                }
+                label={formConfig.addlInfoTitle}
+                labelId="additional-information-label"
+                id="additional-information"
+                hint={
+                  formConfig.addlInfoText ??
+                  "Add anything else that you would like to share with CMS."
+                }
+                disabled={isSubmitting}
+                fieldClassName="summary-field required"
+                multiline
+                onChange={(e) => {
+                  handleInputChange(e);
+                }}
+                value={oneMacFormData.additionalInformation}
+                maxLength={config.MAX_ADDITIONAL_INFO_LENGTH}
+                aria-describedby="character-count"
+                aria-live="off"
+                aria-multiline={true}
+              ></TextField>
+              <span
+                tabIndex={0}
+                id="character-count"
+                aria-label="character-count"
+                aria-live="polite"
+              >
+                {`${
+                  4000 - oneMacFormData.additionalInformation.length
+                } characters remaining`}
+              </span>
+            </>
+          )}
 
           {formConfig.submitInstructionsJSX ?? ""}
 

--- a/services/ui-src/src/page/disable-rai-withdraw/DisableRaiWithdrawForm.tsx
+++ b/services/ui-src/src/page/disable-rai-withdraw/DisableRaiWithdrawForm.tsx
@@ -22,14 +22,7 @@ export const disableRaiWithdrawFormInfo: OneMACFormConfig = {
       progress on this form.
     </p>
   ),
-  addlInfoTitle: "Change Reason",
-  addlInfoText: (
-    <p>
-      Please be descriptive about why this action is being disabled.{" "}
-      <b>Information entered will be visible to both CMS and State users.</b>
-    </p>
-  ) as React.ReactNode,
-  addlInfoRequired: true,
+  noText: true,
   landingPage: ONEMAC_ROUTES.PACKAGE_LIST,
   submitInstructionsJSX: <></>,
   idMustExist: true,

--- a/services/ui-src/src/page/enable-rai-withdraw/EnableRaiWithdrawForm.tsx
+++ b/services/ui-src/src/page/enable-rai-withdraw/EnableRaiWithdrawForm.tsx
@@ -21,14 +21,7 @@ export const enableRaiWithdrawFormInfo: OneMACFormConfig = {
       you will lose your progress on this form.
     </p>
   ),
-  addlInfoTitle: "Change Reason",
-  addlInfoText: (
-    <p>
-      Please be descriptive about why this action is being enabled.{" "}
-      <b>Information entered will be visible to both CMS and State users.</b>
-    </p>
-  ) as React.ReactNode,
-  addlInfoRequired: true,
+  noText: true,
   landingPage: ONEMAC_ROUTES.PACKAGE_LIST,
   submitInstructionsJSX: <></>,
   idMustExist: true,

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -301,12 +301,16 @@ export const DetailSection = ({
                     <Review className="preserve-spacing" heading="Change Made">
                       {adminChange.changeMade}
                     </Review>
-                    <Review
-                      className="preserve-spacing"
-                      heading="Change Reason"
-                    >
-                      {adminChange.changeReason}
-                    </Review>
+                    {!adminChange.changeMade.includes(
+                      "abled State package action to withdraw Formal RAI Response"
+                    ) && (
+                      <Review
+                        className="preserve-spacing"
+                        heading="Change Reason"
+                      >
+                        {adminChange.changeReason}
+                      </Review>
+                    )}
                   </AccordionItem>
                 );
               })}

--- a/tests/cypress/cypress/e2e/Package_Details_Appendix_K_CMS_User.spec.feature
+++ b/tests/cypress/cypress/e2e/Package_Details_Appendix_K_CMS_User.spec.feature
@@ -286,9 +286,7 @@ Feature: Waiver Package Details View: Appendix K Amendment for a CMS User
         Then verify the status on the card is "Pending"
         Then verify Enable Formal RAI Response Withdraw package action exists
         Then click Enable Formal RAI Response Withdraw package action
-        Then type "Automated test to enable an RAI Response withdrawal." in additional info textarea
         Then Click on Submit Button
         Then verify the status on the card is "RAI Response Withdraw Enabled"
         Then verify package actions header is visible
         Then verify Disable Formal RAI Response Withdraw package action exists
-        #Then verify there are no package actions available

--- a/tests/cypress/cypress/e2e/Package_Details_CHIP_SPA_CMS_User.spec.feature
+++ b/tests/cypress/cypress/e2e/Package_Details_CHIP_SPA_CMS_User.spec.feature
@@ -270,9 +270,7 @@ Feature: CHIP SPA CMS Details View - Card View with Actions
         Then verify the status on the card is "Pending"
         Then verify Enable Formal RAI Response Withdraw package action exists
         Then click Enable Formal RAI Response Withdraw package action
-        Then type "Automated test to enable an RAI Response withdrawal." in additional info textarea
         Then Click on Submit Button
         Then verify the status on the card is "RAI Response Withdraw Enabled"
         Then verify package actions header is visible
         Then verify Disable Formal RAI Response Withdraw package action exists
-#        Then verify there are no package actions available

--- a/tests/cypress/cypress/e2e/Package_Details_Initial_Waiver_CMS_User.spec.feature
+++ b/tests/cypress/cypress/e2e/Package_Details_Initial_Waiver_CMS_User.spec.feature
@@ -299,9 +299,7 @@ Feature: Waiver Package Details View: Initial Waivers
         Then verify the status on the card is "Pending"
         Then verify Enable Formal RAI Response Withdraw package action exists
         Then click Enable Formal RAI Response Withdraw package action
-        Then type "Automated test to enable an RAI Response withdrawal." in additional info textarea
         Then Click on Submit Button
         Then verify the status on the card is "RAI Response Withdraw Enabled"
         Then verify package actions header is visible
         Then verify Disable Formal RAI Response Withdraw package action exists
-        #Then verify there are no package actions available

--- a/tests/cypress/cypress/e2e/Package_Details_Medicaid_SPA_CMS_User.spec.feature
+++ b/tests/cypress/cypress/e2e/Package_Details_Medicaid_SPA_CMS_User.spec.feature
@@ -268,7 +268,6 @@ Feature: Medicaid SPA CMS Details View - Card View with Actions
         Then verify the status on the card is "Pending"
         Then verify Enable Formal RAI Response Withdraw package action exists
         Then click Enable Formal RAI Response Withdraw package action
-        Then type "Automated test to enable an RAI Response withdrawal." in additional info textarea
         Then Click on Submit Button
         Then verify the status on the card is "RAI Response Withdraw Enabled"
         Then verify package actions header is visible

--- a/tests/cypress/cypress/e2e/Package_Details_Renewal_Waiver_CMS_User.spec.feature
+++ b/tests/cypress/cypress/e2e/Package_Details_Renewal_Waiver_CMS_User.spec.feature
@@ -290,9 +290,7 @@ Feature: Waiver Package Details View: Waiver Renewal for a CMS User
         Then verify the status on the card is "Pending"
         Then verify Enable Formal RAI Response Withdraw package action exists
         Then click Enable Formal RAI Response Withdraw package action
-        Then type "Automated test to enable an RAI Response withdrawal." in additional info textarea
         Then Click on Submit Button
         Then verify the status on the card is "RAI Response Withdraw Enabled"
         Then verify package actions header is visible
         Then verify Disable Formal RAI Response Withdraw package action exists
-        #Then verify there are no package actions available

--- a/tests/cypress/cypress/e2e/Package_Details_Waiver_Amendment_CMS_User.spec.feature
+++ b/tests/cypress/cypress/e2e/Package_Details_Waiver_Amendment_CMS_User.spec.feature
@@ -258,9 +258,7 @@ Feature: Waiver Package Details View: 1915 b Waiver Amendment for a CMS User
         Then verify the status on the card is "Pending"
         Then verify Enable Formal RAI Response Withdraw package action exists
         Then click Enable Formal RAI Response Withdraw package action
-        Then type "Automated test to enable an RAI Response withdrawal." in additional info textarea
         Then Click on Submit Button
         Then verify the status on the card is "RAI Response Withdraw Enabled"
         Then verify package actions header is visible
         Then verify Disable Formal RAI Response Withdraw package action exists
-        #Then verify there are no package actions available


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-26064
Endpoint: [Click here](https://d2pw7kqcao5lf0.cloudfront.net/)

### Details
As a CMS user, I do not need to provide a change reason when enabling or disabling a RAI Response Withdrawal.

### Changes
- removed the Change Reason from the Enable RAI Response Withdraw and the Disable RAI Response Withdraw forms.
- added a new config option to allow forms to not have the text field 
- removed the Change Reason from any Admin Changes that are for Enable/Disable RAI Response Withdraws

### Test Plan
1. Login as a CMS user
2. Navigate to Dashboard
3. Find a package in Pending Status with an Formal RAI Response date (or, a package in Formal RAI Response Enabled)
4. Go into package details and click the "Enable" action
5. Verify the form no longer requires a reason
6. Verify submitting the form Enables (or Disables) the RAI Response Withdraw
7. Verify that the Admin Changes section does not have a Change Reason for these enabling/disabling actions.
