### PR TITLE
PI1.4 26079: FAQ Search expansion

### DIFF
--- a/services/common/routes.js
+++ b/services/common/routes.js
@@ -10,6 +10,7 @@ export const ROUTES = {
   DETAIL: "/detail",
   USER_MANAGEMENT: "/usermanagement",
   FAQ: "/FAQ",
+  FAQ_OPEN: "/FAQ#open",
   FAQ_ACCEPTED_FILE_TYPES: "/FAQ#acceptable-file-formats",
   FAQ_ATTACHMENTS_MED_SPA: "/FAQ#medicaid-spa-attachments",
   FAQ_ATTACHMENTS_MED_SPA_RAI: "/FAQ#medicaid-spa-rai-attachments",

--- a/services/ui-src/src/containers/FAQ.tsx
+++ b/services/ui-src/src/containers/FAQ.tsx
@@ -1,9 +1,13 @@
 import React, { useEffect, useState } from "react";
 import PageTitleBar from "../components/PageTitleBar";
 import { helpDeskContact } from "../libs/helpDeskContact";
-import { FAQContent, oneMACFAQContent } from "../libs/faq/faqContent";
+import {
+  QuestionAnswer,
+  FAQContent,
+  oneMACFAQContent,
+} from "../libs/faq/faqContent";
 
-import { Accordion, AccordionItem } from "@cmsgov/design-system";
+import { Accordion, AccordionItem, Button } from "@cmsgov/design-system";
 import { MACCard } from "../components/MACCard";
 
 /** Refactored out for later extraction by cms-ux-lib. However, using this
@@ -37,7 +41,36 @@ export const FAQSection = ({ section }: { section: FAQContent }) => {
 };
 
 const FAQ = () => {
+  const [faqItems, setFaqItems] = useState(oneMACFAQContent);
   const [hash, setHash] = useState(window.location.hash.replace("#", ""));
+
+  const toggleAccordianItem = (anchorText: string) => {
+    const newItems = faqItems.map((section) => {
+      return {
+        sectionTitle: section.sectionTitle,
+        qanda: section.qanda.map((qa) => {
+          const openState =
+            qa.anchorText === anchorText ? !qa.isOpen : qa.isOpen;
+          return { ...qa, isOpen: openState } as QuestionAnswer;
+        }),
+      } as FAQContent;
+    });
+    setFaqItems(newItems);
+  };
+
+  const openAll = () => {
+    console.log("faq Items: ", faqItems);
+    const newItems = faqItems.map((section) => {
+      return {
+        sectionTitle: section.sectionTitle,
+        qanda: section.qanda.map((qa) => {
+          return { ...qa, isOpen: true } as QuestionAnswer;
+        }),
+      } as FAQContent;
+    });
+    console.log("New items: ", newItems);
+    setFaqItems(newItems);
+  };
 
   const hashHandler = () => {
     setHash((prev) => {
@@ -97,7 +130,10 @@ const FAQ = () => {
       <PageTitleBar heading="Frequently Asked Questions" />
       <div className="faq-display" id="top">
         <div id="faq-list">
-          {oneMACFAQContent.map((section, idx) => (
+          <Button className="faqButtonLink" onClick={() => openAll()}>
+            Expand all to search with CTRL+F
+          </Button>
+          {faqItems.map((section, idx) => (
             /** To be replaced with {@link FAQSection} */
             <div key={`faq-section-${idx}`} className="faq-section">
               <h2 className="topic-title">{section.sectionTitle}</h2>
@@ -109,6 +145,10 @@ const FAQ = () => {
                       heading={questionAnswer.question}
                       buttonClassName="accordion-button"
                       contentClassName="accordion-content"
+                      isControlledOpen={questionAnswer.isOpen}
+                      onChange={() =>
+                        toggleAccordianItem(questionAnswer.anchorText)
+                      }
                     >
                       {questionAnswer.answerJSX}
                     </AccordionItem>

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -2946,3 +2946,8 @@ article.form-container {
   max-width: 540px;
   margin: 3rem 0;
 }
+
+.faqButtonLink {
+  @extend .ds-c-button;
+  margin: 10px;
+}

--- a/services/ui-src/src/libs/faq/faqContent.tsx
+++ b/services/ui-src/src/libs/faq/faqContent.tsx
@@ -26,7 +26,7 @@ export const oneMACFAQContent: FAQContent[] = [
     qanda: [
       {
         anchorText: "system",
-        isOpen: true,
+        isOpen: false,
         question: "Which system should I use for my state’s submission?",
         answerJSX: (
           <>

--- a/services/ui-src/src/libs/faq/faqContent.tsx
+++ b/services/ui-src/src/libs/faq/faqContent.tsx
@@ -5,8 +5,9 @@ import { stateSystemOverviewTranscript } from "./stateSystemOverviewTranscript";
 import { FILE_TYPES, FileTypesFAQListItem } from "../../utils/fileTypes";
 import config from "../../utils/config";
 
-interface QuestionAnswer {
+export interface QuestionAnswer {
   anchorText: string;
+  isOpen: boolean;
   question: string;
   answerJSX: JSX.Element;
 }
@@ -25,6 +26,7 @@ export const oneMACFAQContent: FAQContent[] = [
     qanda: [
       {
         anchorText: "system",
+        isOpen: true,
         question: "Which system should I use for my state’s submission?",
         answerJSX: (
           <>
@@ -48,6 +50,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "browsers",
+        isOpen: false,
         question: "What browsers can I use to access the system?",
         answerJSX: (
           <p>
@@ -58,6 +61,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "confirm-email",
+        isOpen: false,
         question: "What should we do if we don’t receive a confirmation email?",
         answerJSX: (
           <p>
@@ -72,6 +76,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "is-official",
+        isOpen: false,
         question: "Is this considered the official state submission?",
         answerJSX: (
           <p>
@@ -88,6 +93,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "onemac-roles",
+        isOpen: false,
         question: "What are the OneMAC user roles?",
         answerJSX: (
           <table className="faq-table">
@@ -134,6 +140,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "acceptable-file-formats",
+        isOpen: false,
         question: "What are the kinds of file formats I can upload into OneMAC",
         answerJSX: (
           <section>
@@ -157,6 +164,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "onboarding-materials",
+        isOpen: false,
         question: "Onboarding Materials",
         answerJSX: (
           <>
@@ -198,6 +206,7 @@ export const oneMACFAQContent: FAQContent[] = [
     qanda: [
       {
         anchorText: "spa-id-format",
+        isOpen: false,
         question: "What format is used to enter a SPA ID?",
         answerJSX: (
           <>
@@ -221,6 +230,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "medicaid-spa-attachments",
+        isOpen: false,
         question: "What are the attachments for a Medicaid SPA?",
         answerJSX: (
           <>
@@ -320,6 +330,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "medicaid-spa-rai-attachments",
+        isOpen: false,
         question:
           "What are the attachments for a Medicaid response to Request for Additional Information (RAI)?",
         answerJSX: (
@@ -354,6 +365,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "chip-spa-attachments",
+        isOpen: false,
         question: "What are the attachments for a CHIP SPA?",
         answerJSX: (
           <>
@@ -422,6 +434,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "chip-spa-rai-attachments",
+        isOpen: false,
         question:
           "What are the attachments for a CHIP SPA response to Request for Additional Information (RAI)?",
         answerJSX: (
@@ -486,6 +499,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "public-health-emergency",
+        isOpen: false,
         question:
           "Can I submit SPAs relating to the Public Health Emergency (PHE) in OneMAC?",
         answerJSX: (
@@ -502,6 +516,7 @@ export const oneMACFAQContent: FAQContent[] = [
     qanda: [
       {
         anchorText: "initial-waiver-id-format",
+        isOpen: false,
         question:
           "What format is used to enter a 1915(b) Initial Waiver number?",
         answerJSX: (
@@ -528,6 +543,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "waiver-renewal-id-format",
+        isOpen: false,
         question:
           "What format is used to enter a 1915(b) Waiver Renewal number?",
         answerJSX: (
@@ -554,6 +570,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "waiver-amendment-id-format",
+        isOpen: false,
         question:
           "What format is used to enter a 1915(b) Waiver Amendment number?",
         answerJSX: (
@@ -581,6 +598,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "waiver-id-help",
+        isOpen: false,
         question:
           "Who can I contact to help me figure out the correct 1915(b) Waiver Number?",
         answerJSX: (
@@ -595,6 +613,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "waiver-c-id",
+        isOpen: false,
         question: "What format is used to enter a 1915(c) waiver number?",
         answerJSX: (
           <>
@@ -624,6 +643,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "waiverb-attachments",
+        isOpen: false,
         question:
           "What attachments are needed to submit a 1915(b) waiver action?",
         answerJSX: (
@@ -707,6 +727,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "waiverb-rai-attachments",
+        isOpen: false,
         question:
           "What are the attachments for a 1915(b) Waiver response to Request for Additional Information (RAI)?",
         answerJSX: (
@@ -743,6 +764,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "waiver-extension-id-format",
+        isOpen: false,
         question:
           "What format is used to enter a 1915(b) and 1915(c) Temporary Extension number?",
         answerJSX: (
@@ -776,6 +798,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "waiver-extension-status",
+        isOpen: false,
         question:
           "Why does the status of my Temporary Extension Request continue to show as 'Submitted'?",
         answerJSX: (
@@ -791,6 +814,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "waiverb-extension-attachments",
+        isOpen: false,
         question:
           "What are the attachments for a 1915(b) Waiver - Request for Temporary Extension?",
         answerJSX: (
@@ -826,6 +850,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "waiverc-extension-attachments",
+        isOpen: false,
         question:
           "What are the attachments for a 1915(c) Waiver - Request for Temporary Extension",
         answerJSX: (
@@ -861,6 +886,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "appk",
+        isOpen: false,
         question: "Can I submit Appendix K amendments in OneMAC?",
         answerJSX: (
           <p>
@@ -871,6 +897,7 @@ export const oneMACFAQContent: FAQContent[] = [
       },
       {
         anchorText: "appk-attachments",
+        isOpen: false,
         question: "What are the attachments for a 1915(c) Appendix K Waiver?",
         answerJSX: (
           <>


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-26079
Endpoint: See github-actions bot comment

### Details
Add an "Expand all" button to the FAQ page to allow Ctrl-F to search all FAQ text.

### Changes
- moved the FAQ content into the React state to get native rendering
- added isOpen to the faqcontent items in json
- switched the Accordian component from default to Controlled open to allow the application to open and close the questions
- added the handler for opening and closing
- added a button at the top of the page that opens all the questions

### Implementation Notes
To do this properly, would really be best to remove the hashHandler and use the state to manage which item shows, etc.  Also, there is probably value in dividing the components even further, so a change to one QandA doesn't have to alter the entire faq content state to render.  HOWEVER, this was only a 2 point story and it does not look like our work on the FAQ page is going to be migrated.

Also note... using the Expand button does NOT automatically re-trigger the Ctrl-F search in the browser - you have to edit the text to be searched in some way.

### Test Plan
1. Open the application
2. Click the FAQ link
3. Click the "Expand all to search with CTRL+F" button
4. Verify the all sections expand
5. Verify text is searchable
6. Verify other application FAQ links work as before (expanding and moving to correct places)
