### PR TITLE
PI1.05 26320: Add the Package Withdrawn Date to the Package Details

### DIFF
--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -262,6 +262,12 @@ export const buildAnyPackage = async (packageId, config) => {
                   "yyyy-LL-dd"
                 )
               : emptyField;
+          putParams.Item.packageWithdrawnDate =
+            oneMacStatus === ONEMAC_STATUS.WITHDRAWN
+              ? DateTime.fromMillis(anEvent.STATE_PLAN.STATUS_DATE).toFormat(
+                  "yyyy-LL-dd"
+                )
+              : emptyField;
         }
       }
 

--- a/services/ui-src/src/libs/detailLib.ts
+++ b/services/ui-src/src/libs/detailLib.ts
@@ -70,6 +70,11 @@ export const finalDispositionDateDefault: AttributeDetail = {
   fieldName: "finalDispositionDateNice",
   default: "-- --",
 };
+export const packageWithdrawnDateDefault: AttributeDetail = {
+  heading: "Package Withdrawn Date",
+  fieldName: "packageWithdrawnDateNice",
+  default: null,
+};
 export const subjectDefault: AttributeDetail = {
   heading: "Subject",
   fieldName: "subject",
@@ -138,6 +143,7 @@ export const defaultDetailSectionItems = [
   proposedEffectiveDateDefault,
   approvedEffectiveDateDefault,
   finalDispositionDateDefault,
+  packageWithdrawnDateDefault,
   latestRaiResponseDateDefault,
   blankBox, // empty space
   subjectDefault,

--- a/services/ui-src/src/page/DetailView.tsx
+++ b/services/ui-src/src/page/DetailView.tsx
@@ -157,6 +157,15 @@ const DetailView: React.FC<{ pageConfig: OneMACDetail }> = ({ pageConfig }) => {
             "MMM d yyyy"
           );
         } else fetchedDetail.finalDispositionDateNice = "-- --";
+        if (
+          fetchedDetail.packageWithdrawnDate &&
+          fetchedDetail.packageWithdrawnDate !== "-- --"
+        ) {
+          fetchedDetail.packageWithdrawnDateNice = format(
+            parseISO(fetchedDetail.packageWithdrawnDate),
+            "MMM d yyyy"
+          );
+        } else fetchedDetail.packageWithdrawnDateNice = "-- --";
         stillLoading = false;
       } catch (e) {
         console.log("error in getDetail call?? ", e);


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-26320
Endpoint: See github-actions bot comment

### Details
CMS has requested that the Package Withdrawn date be added to the dashboard for use in reports.  The first step is to add it to the package item details.

Note... Package Withdrawn is a Final Disposition status, so the same date is being used for both fields.

### Changes
- added the packageWithdrawnDate to the package item, filled in similarly to the finalDispositionDate (but only for packages in "Package Withdrawn"/"Withdrawn" status
- added the front end code to put the date into the package details - NOTE: the AC specifies formatting like the Initial Submission Date, but the data field we get from SEA Tool does not have that much detail, so instead, it is formatted like the final disposition date.

### Implementation Notes
Thank you so much, Brandon and Kevin, for organizing the front end code so nicely!!  I did not think this would be a difficult feature to add, but it was SUPER EASY because of how you two did your previous work!  Thanks!!

### Test Plan
1. Login as a state user
2. Navigate to dashboard
3. Click into the details for a package in Package Withdrawn status
4. Verify the date is correct (should match the final disposition date)
5. Click into the details for a package NOT in Package Withdrawn status
6. Date should have "-- --"

1. Login as CMS user
2. Navigate to dashboard
3. Click into the details for a package in Package Withdrawn status
4. Verify the date is correct (should match the final disposition date)
5. Click into the details for a package NOT in Package Withdrawn status
6. Date should have "-- --" 