### PR TITLE
PI1.05 26321: Add Final Disposition to the Dashboard

### DIFF
--- a/services/app-api/getMyPackages.js
+++ b/services/app-api/getMyPackages.js
@@ -42,7 +42,7 @@ export const getMyPackages = async (email, group) => {
         ExclusiveStartKey: null,
         ScanIndexForward: false,
         ProjectionExpression:
-          "componentId,componentType,currentStatus,submissionTimestamp,latestRaiResponseTimestamp,submitterName,submitterEmail,waiverAuthority, cpocName, reviewTeam, subStatus, finalDispositionDate",
+          "componentId,componentType,currentStatus,submissionTimestamp,latestRaiResponseTimestamp,submitterName,submitterEmail,waiverAuthority, cpocName, reviewTeam, subStatus, finalDispositionTimestamp",
       };
       const grouppk = "OneMAC#" + group;
       let paramList = [];

--- a/services/app-api/getMyPackages.js
+++ b/services/app-api/getMyPackages.js
@@ -42,7 +42,7 @@ export const getMyPackages = async (email, group) => {
         ExclusiveStartKey: null,
         ScanIndexForward: false,
         ProjectionExpression:
-          "componentId,componentType,currentStatus,submissionTimestamp,latestRaiResponseTimestamp,submitterName,submitterEmail,waiverAuthority, cpocName, reviewTeam, subStatus, finalDispositionTimestamp",
+          "componentId,componentType,currentStatus,submissionTimestamp,latestRaiResponseTimestamp,submitterName,submitterEmail,waiverAuthority, cpocName, reviewTeam, subStatus, finalDispositionDate",
       };
       const grouppk = "OneMAC#" + group;
       let paramList = [];

--- a/services/app-api/getMyPackages.js
+++ b/services/app-api/getMyPackages.js
@@ -42,7 +42,7 @@ export const getMyPackages = async (email, group) => {
         ExclusiveStartKey: null,
         ScanIndexForward: false,
         ProjectionExpression:
-          "componentId,componentType,currentStatus,submissionTimestamp,latestRaiResponseTimestamp,submitterName,submitterEmail,waiverAuthority, cpocName, reviewTeam, subStatus",
+          "componentId,componentType,currentStatus,submissionTimestamp,latestRaiResponseTimestamp,submitterName,submitterEmail,waiverAuthority, cpocName, reviewTeam, subStatus, finalDispositionDate",
       };
       const grouppk = "OneMAC#" + group;
       let paramList = [];

--- a/services/app-api/seed-data/all-data.json
+++ b/services/app-api/seed-data/all-data.json
@@ -9804,6 +9804,7 @@
         "currentStatus": "Disapproved",
         "description": "disapproved test - another thing that might be overwritten",
         "finalDispositionDate": "2023-01-12",
+        "finalDispositionTimestamp": 1673499600000,
         "GSI1pk": "OneMAC#spa",
         "GSI1sk": "MD-22-2301-VM",
         "lastEventTimestamp": 1673561667690,

--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -256,17 +256,12 @@ export const buildAnyPackage = async (packageId, config) => {
         if (seaToolStatus && SEATOOL_TO_ONEMAC_STATUS[seaToolStatus]) {
           const oneMacStatus = SEATOOL_TO_ONEMAC_STATUS[seaToolStatus];
           putParams.Item.currentStatus = oneMacStatus;
-          if (finalDispositionStatuses.includes(oneMacStatus)) {
-            putParams.Item.finalDispositionDate = DateTime.fromMillis(
-              anEvent.STATE_PLAN.STATUS_DATE
-            ).toFormat("yyyy-LL-dd");
-            // have to add 18000000 seconds because of time zone
-            putParams.Item.finalDispositionTimestamp =
-              anEvent.STATE_PLAN.STATUS_DATE + 18000009;
-          } else {
-            putParams.Item.finalDispositionDate = emptyField;
-            putParams.Item.finalDispositionTimestamp = 0;
-          }
+          putParams.Item.finalDispositionDate =
+            finalDispositionStatuses.includes(oneMacStatus)
+              ? DateTime.fromMillis(anEvent.STATE_PLAN.STATUS_DATE).toFormat(
+                  "yyyy-LL-dd"
+                )
+              : emptyField;
         }
       }
 

--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -262,6 +262,8 @@ export const buildAnyPackage = async (packageId, config) => {
                   "yyyy-LL-dd"
                 )
               : emptyField;
+          putParams.Item.finalDispositionTimestamp =
+            anEvent.STATE_PLAN.STATUS_DATE + 18000000;
         }
       }
 

--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -256,14 +256,17 @@ export const buildAnyPackage = async (packageId, config) => {
         if (seaToolStatus && SEATOOL_TO_ONEMAC_STATUS[seaToolStatus]) {
           const oneMacStatus = SEATOOL_TO_ONEMAC_STATUS[seaToolStatus];
           putParams.Item.currentStatus = oneMacStatus;
-          putParams.Item.finalDispositionDate =
-            finalDispositionStatuses.includes(oneMacStatus)
-              ? DateTime.fromMillis(anEvent.STATE_PLAN.STATUS_DATE).toFormat(
-                  "yyyy-LL-dd"
-                )
-              : emptyField;
-          putParams.Item.finalDispositionTimestamp =
-            anEvent.STATE_PLAN.STATUS_DATE + 18000000;
+          if (finalDispositionStatuses.includes(oneMacStatus)) {
+            putParams.Item.finalDispositionDate = DateTime.fromMillis(
+              anEvent.STATE_PLAN.STATUS_DATE
+            ).toFormat("yyyy-LL-dd");
+            // have to add 18000000 seconds because of time zone
+            putParams.Item.finalDispositionTimestamp =
+              anEvent.STATE_PLAN.STATUS_DATE + 18000000;
+          } else {
+            putParams.Item.finalDispositionDate = emptyField;
+            putParams.Item.finalDispositionTimestamp = 0;
+          }
         }
       }
 

--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -262,7 +262,7 @@ export const buildAnyPackage = async (packageId, config) => {
             ).toFormat("yyyy-LL-dd");
             // have to add 18000000 seconds because of time zone
             putParams.Item.finalDispositionTimestamp =
-              anEvent.STATE_PLAN.STATUS_DATE + 18000000;
+              anEvent.STATE_PLAN.STATUS_DATE + 18000009;
           } else {
             putParams.Item.finalDispositionDate = emptyField;
             putParams.Item.finalDispositionTimestamp = 0;

--- a/services/ui-src/src/components/FilterChipTray.tsx
+++ b/services/ui-src/src/components/FilterChipTray.tsx
@@ -33,6 +33,7 @@ export const FilterChipTray = ({
     [COLUMN_ID.TYPE]: "Type",
     [COLUMN_ID.STATUS]: "Status",
     [COLUMN_ID.SUBMISSION_TIMESTAMP]: "Initial Submission",
+    [COLUMN_ID.FINAL_DISPOSITION_TIMESTAMP]: "Final Disposition",
     [COLUMN_ID.LATEST_RAI_TIMESTAMP]: "Formal RAI Response",
   };
   const Chip = ({ label: value, column, type }: FilterChipValue) => {

--- a/services/ui-src/src/components/FilterChipTray.tsx
+++ b/services/ui-src/src/components/FilterChipTray.tsx
@@ -33,7 +33,7 @@ export const FilterChipTray = ({
     [COLUMN_ID.TYPE]: "Type",
     [COLUMN_ID.STATUS]: "Status",
     [COLUMN_ID.SUBMISSION_TIMESTAMP]: "Initial Submission",
-    [COLUMN_ID.FINAL_DISPOSITION_TIMESTAMP]: "Final Disposition",
+    [COLUMN_ID.FINAL_DISPOSITION_DATE]: "Final Disposition",
     [COLUMN_ID.LATEST_RAI_TIMESTAMP]: "Formal RAI Response",
   };
   const Chip = ({ label: value, column, type }: FilterChipValue) => {

--- a/services/ui-src/src/components/SearchAndFilter.tsx
+++ b/services/ui-src/src/components/SearchAndFilter.tsx
@@ -210,9 +210,17 @@ const filterFromMultiCheckbox = <
     filterValue.includes(cellValue)
   );
 
-const betweenDates = (dateA: Date, dateB: Date, epoch: number) => {
-  const dateFromValue = new Date(epoch);
-  return dateFromValue > dateA && dateFromValue < dateB;
+const betweenDates = (dateA: Date, dateB: Date, epoch: number | string) => {
+  let dateFromValue;
+
+  if (typeof epoch === "string" && epoch !== "-- --") {
+    const [year, month, day] = epoch.split("-");
+    // in Date objects, month is an index (starts at 0), year and day are not
+    dateFromValue = new Date(Number(year), Number(month) - 1, Number(day));
+  } else {
+    dateFromValue = new Date(epoch);
+  }
+  return dateFromValue >= dateA && dateFromValue <= dateB;
 };
 
 const filterFromDateRange = <

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -7,7 +7,7 @@ import React, {
 } from "react";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import { Button } from "@cmsgov/design-system";
-import { format, getUnixTime } from "date-fns";
+import { format } from "date-fns";
 import classNames from "classnames";
 
 import {

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -48,7 +48,7 @@ export const COLUMN_ID = {
   TYPE: "componentType",
   STATUS: "packageStatus",
   SUBMISSION_TIMESTAMP: "submissionTimestamp",
-  FINAL_DISPOSITION_TIMESTAMP: "finalDispositionTimestamp",
+  FINAL_DISPOSITION_DATE: "finalDispositionDate",
   LATEST_RAI_TIMESTAMP: "latestRaiResponseTimestamp",
   CPOC_NAME: "cpocName",
   SUBMITTER: "submitter",
@@ -58,12 +58,12 @@ export const COLUMN_ID = {
 const defaultStateHiddenCols = [
   COLUMN_ID.TERRITORY,
   COLUMN_ID.CPOC_NAME,
-  COLUMN_ID.FINAL_DISPOSITION_TIMESTAMP,
+  COLUMN_ID.FINAL_DISPOSITION_DATE,
 ];
 const defaultCMSHiddenCols = [
   COLUMN_ID.SUBMITTER,
   COLUMN_ID.CPOC_NAME,
-  COLUMN_ID.FINAL_DISPOSITION_TIMESTAMP,
+  COLUMN_ID.FINAL_DISPOSITION_DATE,
 ];
 
 const DEFAULT_COLUMNS = {
@@ -76,10 +76,35 @@ const DEFAULT_COLUMNS = {
   [USER_ROLE.DEFAULT_CMS_USER]: defaultCMSHiddenCols,
 };
 
+const shortMonth = [
+  "none",
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
 const renderDate = ({ value }) =>
   typeof value === "number" && value > 0
     ? format(value, "MMM d, yyyy")
     : "-- --";
+
+const renderStringDate = ({ value }) => {
+  let returnValue = "-- --";
+  if (value && value !== "-- --") {
+    const [year, month, day] = value.split("-");
+    returnValue = `${shortMonth[Number(month)]} ${day}, ${year}`;
+  }
+  return returnValue;
+};
 
 export const getState = ({ componentId }) =>
   componentId ? componentId.toString().substring(0, 2) : "--";
@@ -216,7 +241,6 @@ const PackageList = () => {
   const exportTransformMap = {
     submissionTimestamp: renderDate,
     latestRaiResponseTimestamp: renderDate,
-    finalDispositionTimestamp: renderDate,
   };
 
   const columns = useMemo(
@@ -266,8 +290,8 @@ const PackageList = () => {
         },
         {
           Header: "Final Disposition",
-          accessor: COLUMN_ID.FINAL_DISPOSITION_TIMESTAMP,
-          Cell: renderDate,
+          accessor: COLUMN_ID.FINAL_DISPOSITION_DATE,
+          Cell: renderStringDate,
           disableFilters: false,
           filter: CustomFilterTypes.DateRange,
           Filter: CustomFilterUi.DateRangeInPast,

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -7,7 +7,7 @@ import React, {
 } from "react";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import { Button } from "@cmsgov/design-system";
-import { format } from "date-fns";
+import { format, getUnixTime } from "date-fns";
 import classNames from "classnames";
 
 import {
@@ -48,7 +48,7 @@ export const COLUMN_ID = {
   TYPE: "componentType",
   STATUS: "packageStatus",
   SUBMISSION_TIMESTAMP: "submissionTimestamp",
-  FINAL_DISPOSITION_DATE: "finalDispositionDate",
+  FINAL_DISPOSITION_TIMESTAMP: "finalDispositionTimestamp",
   LATEST_RAI_TIMESTAMP: "latestRaiResponseTimestamp",
   CPOC_NAME: "cpocName",
   SUBMITTER: "submitter",
@@ -58,12 +58,12 @@ export const COLUMN_ID = {
 const defaultStateHiddenCols = [
   COLUMN_ID.TERRITORY,
   COLUMN_ID.CPOC_NAME,
-  COLUMN_ID.FINAL_DISPOSITION_DATE,
+  COLUMN_ID.FINAL_DISPOSITION_TIMESTAMP,
 ];
 const defaultCMSHiddenCols = [
   COLUMN_ID.SUBMITTER,
   COLUMN_ID.CPOC_NAME,
-  COLUMN_ID.FINAL_DISPOSITION_DATE,
+  COLUMN_ID.FINAL_DISPOSITION_TIMESTAMP,
 ];
 
 const DEFAULT_COLUMNS = {
@@ -216,6 +216,7 @@ const PackageList = () => {
   const exportTransformMap = {
     submissionTimestamp: renderDate,
     latestRaiResponseTimestamp: renderDate,
+    finalDispositionTimestamp: renderDate,
   };
 
   const columns = useMemo(
@@ -265,7 +266,7 @@ const PackageList = () => {
         },
         {
           Header: "Final Disposition Date",
-          accessor: COLUMN_ID.FINAL_DISPOSITION_DATE,
+          accessor: COLUMN_ID.FINAL_DISPOSITION_TIMESTAMP,
           Cell: renderDate,
           disableFilters: false,
           filter: CustomFilterTypes.DateRange,

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -48,14 +48,23 @@ export const COLUMN_ID = {
   TYPE: "componentType",
   STATUS: "packageStatus",
   SUBMISSION_TIMESTAMP: "submissionTimestamp",
+  FINAL_DISPOSITION_DATE: "finalDispositionDate",
   LATEST_RAI_TIMESTAMP: "latestRaiResponseTimestamp",
   CPOC_NAME: "cpocName",
   SUBMITTER: "submitter",
   ACTIONS: "packageActions",
 };
 
-const defaultStateHiddenCols = [COLUMN_ID.TERRITORY, COLUMN_ID.CPOC_NAME];
-const defaultCMSHiddenCols = [COLUMN_ID.SUBMITTER, COLUMN_ID.CPOC_NAME];
+const defaultStateHiddenCols = [
+  COLUMN_ID.TERRITORY,
+  COLUMN_ID.CPOC_NAME,
+  COLUMN_ID.FINAL_DISPOSITION_DATE,
+];
+const defaultCMSHiddenCols = [
+  COLUMN_ID.SUBMITTER,
+  COLUMN_ID.CPOC_NAME,
+  COLUMN_ID.FINAL_DISPOSITION_DATE,
+];
 
 const DEFAULT_COLUMNS = {
   [USER_ROLE.STATE_SUBMITTER]: defaultStateHiddenCols,
@@ -249,6 +258,14 @@ const PackageList = () => {
         {
           Header: "Initial Submission",
           accessor: COLUMN_ID.SUBMISSION_TIMESTAMP,
+          Cell: renderDate,
+          disableFilters: false,
+          filter: CustomFilterTypes.DateRange,
+          Filter: CustomFilterUi.DateRangeInPast,
+        },
+        {
+          Header: "Final Disposition Date",
+          accessor: COLUMN_ID.FINAL_DISPOSITION_DATE,
           Cell: renderDate,
           disableFilters: false,
           filter: CustomFilterTypes.DateRange,

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -265,7 +265,7 @@ const PackageList = () => {
           Filter: CustomFilterUi.DateRangeInPast,
         },
         {
-          Header: "Final Disposition Date",
+          Header: "Final Disposition",
           accessor: COLUMN_ID.FINAL_DISPOSITION_TIMESTAMP,
           Cell: renderDate,
           disableFilters: false,

--- a/tests/cypress/cypress/e2e/Dashboard_Column_Picker_SPA_CMS.spec.feature
+++ b/tests/cypress/cypress/e2e/Dashboard_Column_Picker_SPA_CMS.spec.feature
@@ -14,6 +14,7 @@ Feature: Package Dashboard - SPA Tab Column Picker for CMS User
         Then verify Formal RAI Received column exists
         Then verify submitted by column does not exist
         Then verify CPOC Name column does not exist
+        Then verify Final Disposition column does not exist
         Then click show hide columns button
         Then verify Formal RAI Received checkbox exists
         Then verify Initial Submission Date checkbox exists
@@ -22,6 +23,7 @@ Feature: Package Dashboard - SPA Tab Column Picker for CMS User
         Then verify submitted by checkbox exists
         Then verify type checkbox exists
         Then verify CPOC Name checkbox exists
+        Then verify Final Disposition checkbox exists
         Then click show hide columns button
 
     Scenario: SPAs Tab - Uncheck all and verify SPA ID exists
@@ -32,6 +34,7 @@ Feature: Package Dashboard - SPA Tab Column Picker for CMS User
         Then click status checkbox
         Then click type checkbox
         Then click CPOC Name checkbox
+        Then click Final Disposition checkbox
         Then click show hide columns button
         Then verify SPA ID column exists
         Then verify type column does not exist
@@ -40,6 +43,7 @@ Feature: Package Dashboard - SPA Tab Column Picker for CMS User
         Then verify Initial Submission Date column does not exist
         Then verify submitted by column does not exist
         Then verify CPOC Name column exists
+        Then verify Final Disposition column exists
         Then verify Formal RAI Received column does not exist
         Then Click on My Account
         Then click the logout button

--- a/tests/cypress/cypress/e2e/Dashboard_Column_Picker_SPA_State.spec.feature
+++ b/tests/cypress/cypress/e2e/Dashboard_Column_Picker_SPA_State.spec.feature
@@ -14,6 +14,7 @@ Feature: Package Dashboard - SPA Tab Column Picker
         Then verify submitted by column exists
         Then verify CPOC Name column does not exist
         Then verify actions column exists
+        Then verify Final Disposition column does not exist
         Then verify Formal RAI Received column exists
         Then click show hide columns button
         Then verify Formal RAI Received checkbox exists
@@ -24,6 +25,7 @@ Feature: Package Dashboard - SPA Tab Column Picker
         Then verify type checkbox exists
         Then verify Formal RAI Received checkbox exists
         Then verify CPOC Name checkbox exists
+        Then verify Final Disposition checkbox exists
         Then click show hide columns button
 
     Scenario: SPAs Tab - Uncheck all and verify SPA ID and actions exists
@@ -34,6 +36,7 @@ Feature: Package Dashboard - SPA Tab Column Picker
         Then click submitted by checkbox
         Then click type checkbox
         Then click CPOC Name checkbox
+        Then click Final Disposition checkbox
         Then click show hide columns button
         Then verify SPA ID column exists
         Then verify actions column exists
@@ -42,6 +45,7 @@ Feature: Package Dashboard - SPA Tab Column Picker
         Then verify status column does not exist
         Then verify Initial Submission Date column does not exist
         Then verify submitted by column does not exist
+        Then verify Final Disposition column exists
         Then verify Formal RAI Received column does not exist
         Then verify CPOC Name column exists
         Then Click on My Account

--- a/tests/cypress/cypress/e2e/Dashboard_Column_Picker_Waiver_CMS.spec.feature
+++ b/tests/cypress/cypress/e2e/Dashboard_Column_Picker_Waiver_CMS.spec.feature
@@ -16,6 +16,7 @@ Feature: Package Dashboard - Waiver Tab Column Picker for CMS User
         Then verify Formal RAI Received column exists
         Then verify submitted by column does not exist
         Then verify CPOC Name column does not exist
+        Then verify Final Disposition column does not exist
         Then click show hide columns button
         Then verify Formal RAI Received checkbox exists
         Then verify state checkbox exists
@@ -24,6 +25,7 @@ Feature: Package Dashboard - Waiver Tab Column Picker for CMS User
         Then verify submitted by checkbox exists
         Then verify type checkbox exists
         Then verify CPOC Name checkbox exists
+        Then verify Final Disposition checkbox exists
         Then click show hide columns button
         Then Click on My Account
         Then click the logout button
@@ -37,6 +39,7 @@ Feature: Package Dashboard - Waiver Tab Column Picker for CMS User
         Then click status checkbox
         Then click type checkbox
         Then click CPOC Name checkbox
+        Then click Final Disposition checkbox
         Then click show hide columns button
         Then verify Waiver Number column exists
         Then verify type column does not exist
@@ -45,6 +48,7 @@ Feature: Package Dashboard - Waiver Tab Column Picker for CMS User
         Then verify Initial Submission Date column does not exist
         Then verify submitted by column does not exist
         Then verify Formal RAI Received column does not exist
+        Then verify Final Disposition column exists
         Then verify CPOC Name column exists
         Then Click on My Account
         Then click the logout button

--- a/tests/cypress/cypress/e2e/Dashboard_Column_Picker_Waiver_State.spec.feature
+++ b/tests/cypress/cypress/e2e/Dashboard_Column_Picker_Waiver_State.spec.feature
@@ -17,6 +17,7 @@ Feature: Package Dashboard - Waiver Tab Column Picker
         Then verify actions column exists
         Then verify Formal RAI Received column exists
         Then verify CPOC Name column does not exist
+        Then verify Final Disposition column does not exist
         Then click show hide columns button
         Then verify Formal RAI Received checkbox exists
         Then verify state checkbox exists
@@ -25,6 +26,7 @@ Feature: Package Dashboard - Waiver Tab Column Picker
         Then verify submitted by checkbox exists
         Then verify type checkbox exists
         Then verify CPOC Name checkbox exists
+        Then verify Final Disposition checkbox exists
         Then click show hide columns button
         Then Click on My Account
         Then click the logout button
@@ -37,6 +39,7 @@ Feature: Package Dashboard - Waiver Tab Column Picker
         Then click Initial Submission Date checkbox
         Then click type checkbox
         Then click CPOC Name checkbox
+        Then click Final Disposition checkbox
         Then click show hide columns button
         Then verify Waiver Number column exists
         Then verify actions column exists
@@ -46,6 +49,7 @@ Feature: Package Dashboard - Waiver Tab Column Picker
         Then verify Initial Submission Date column does not exist
         Then verify submitted by column does not exist
         Then verify Formal RAI Received column does not exist
+        Then verify Final Disposition column exists
         Then verify CPOC Name column exists
         Then Click on My Account
         Then click the logout button

--- a/tests/cypress/cypress/e2e/Dashboard_Filter.spec.feature
+++ b/tests/cypress/cypress/e2e/Dashboard_Filter.spec.feature
@@ -17,6 +17,7 @@ Feature: Package Dashboard - Filter
         Then click on Initial Submission Date filter dropdown
         Then verify Initial Submission Date date picker filter exists
         Then verify Formal RAI Received dropdown filter exists
+        Then verify Final Disposition dropdown filter exists
         Then Click on My Account
         Then click the logout button
 
@@ -34,6 +35,7 @@ Feature: Package Dashboard - Filter
         Then click on Initial Submission Date filter dropdown
         Then verify Initial Submission Date date picker filter exists
         Then verify Formal RAI Received dropdown filter exists
+        Then verify Final Disposition dropdown filter exists
         Then Click on My Account
         Then click the logout button
 

--- a/tests/cypress/cypress/e2e/Dashboard_Filter_CMS.spec.feature
+++ b/tests/cypress/cypress/e2e/Dashboard_Filter_CMS.spec.feature
@@ -15,6 +15,7 @@ Feature: Package Dashboard - Filter
         Then verify status DropDown Filter exists
         Then verify Initial Submission Date filter dropdown exists
         Then verify Formal RAI Received dropdown filter exists
+        Then verify Final Disposition dropdown filter exists
         Then Click on My Account
         Then click the logout button
 
@@ -30,6 +31,7 @@ Feature: Package Dashboard - Filter
         Then verify status DropDown Filter exists
         Then verify Initial Submission Date filter dropdown exists
         Then verify Formal RAI Received dropdown filter exists
+        Then verify Final Disposition dropdown filter exists
         Then Click on My Account
         Then click the logout button
 

--- a/tests/cypress/cypress/e2e/Dashboard_Filter_options_that_include_Dates.spec.feature
+++ b/tests/cypress/cypress/e2e/Dashboard_Filter_options_that_include_Dates.spec.feature
@@ -29,7 +29,15 @@ Feature: Package Dashboard - Filter options that include Dates
         Then click on Formal RAI Received date picker filter
         Then click on quarter to date date picker button
         Then Click on Filter Button
-        Then verify Initial Submission Date column one date is this quarter
+        Then Click on My Account
+        Then click the logout button
+    
+    Scenario: Filter by Final Disposition - Date picker
+        Then Click on Filter Button
+        Then click on Final Disposition dropdown filter
+        Then click on Final Disposition date picker filter
+        Then click on quarter to date date picker button
+        Then Click on Filter Button
         Then Click on My Account
         Then click the logout button
     

--- a/tests/cypress/cypress/e2e/Dashboard_Filter_options_that_include_Dates_CMS.spec.feature
+++ b/tests/cypress/cypress/e2e/Dashboard_Filter_options_that_include_Dates_CMS.spec.feature
@@ -20,7 +20,15 @@ Feature: Package Dashboard - Filter by Formal RAI Received
         Then click on Formal RAI Received date picker filter
         Then click on quarter to date date picker button
         Then Click on Filter Button
-        Then verify Initial Submission Date column one date is this quarter
+        Then Click on My Account
+        Then click the logout button
+    
+    Scenario: Filter by Final Disposition - Date picker
+        Then Click on Filter Button
+        Then click on Final Disposition dropdown filter
+        Then click on Final Disposition date picker filter
+        Then click on quarter to date date picker button
+        Then Click on Filter Button
         Then Click on My Account
         Then click the logout button
 

--- a/tests/cypress/cypress/e2e/common/steps.js
+++ b/tests/cypress/cypress/e2e/common/steps.js
@@ -1296,6 +1296,9 @@ Then("verify CPOC Name checkbox exists", () => {
 Then("verify Formal RAI Received checkbox exists", () => {
   OneMacPackagePage.verifyFormalRAIReceivedCheckboxExists();
 });
+Then("verify Final Disposition checkbox exists", () => {
+  OneMacPackagePage.verifyFinalDispositionCheckBoxExists();
+});
 Then("verify Initial Submission Date column exists", () => {
   OneMacPackagePage.verifyinitialSubmissionDateColumnExists();
 });
@@ -1329,6 +1332,12 @@ Then("verify CPOC Name column exists", () => {
 Then("verify CPOC Name column does not exist", () => {
   OneMacPackagePage.verifyCPOCNameColumnDoesNotExist();
 });
+Then("verify Final Disposition column exists", () => {
+  OneMacPackagePage.verifyFinalDispositionColumnExists();
+});
+Then("verify Final Disposition column does not exist", () => {
+  OneMacPackagePage.verifyFinalDispositionColumnDoesNotExist();
+});
 Then("click Initial Submission Date checkbox", () => {
   OneMacPackagePage.clickCheckBoxInitialSubmissionDate();
 });
@@ -1349,6 +1358,9 @@ Then("click CPOC Name checkbox", () => {
 });
 Then("click Formal RAI Received checkbox", () => {
   OneMacPackagePage.clickFormalRAIReceivedCheckbox();
+});
+Then("click Final Disposition checkbox", () => {
+  OneMacPackagePage.clickFinalDispositionDateCheckBox();
 });
 Then("verify type column does not exist", () => {
   OneMacPackagePage.verifytypeColumnDoesNotExist();
@@ -1389,6 +1401,9 @@ Then("click on Initial Submission Date date picker filter", () => {
 Then("click on Formal RAI Received date picker filter", () => {
   OneMacPackagePage.clickOnFormalRAIReceivedDatePickerFilter();
 });
+Then("click on Final Disposition date picker filter", () => {
+  OneMacPackagePage.clickOnFinalDispositionDatePickerFilter();
+});
 Then("click on this quarter date picker button", () => {
   OneMacPackagePage.clickOnThisQuarterDatePickerBtn();
 });
@@ -1420,6 +1435,12 @@ Then("verify Formal RAI Received dropdown filter exists", () => {
 });
 Then("click on Formal RAI Received dropdown filter", () => {
   OneMacPackagePage.clickOnFormalRAIReceivedDateFilterDropdownDropDown();
+});
+Then("verify Final Disposition dropdown filter exists", () => {
+  OneMacPackagePage.verifyFinalDispositionDateFilterDropdownExists();
+});
+Then("click on Final Disposition dropdown filter", () => {
+  OneMacPackagePage.clickOnFinalDispositionDateFilterDropdownDropDown();
 });
 Then("verify state filter select exists", () => {
   OneMacPackagePage.verifyStateFilterSelectExists();
@@ -2501,7 +2522,8 @@ Then(
   "verify the sub status on the card is RAI Response Withdraw Enabled",
   () => {
     OneMacPackageDetailsPage.verifyTheSubStatus();
-});
+  }
+);
 Then("verify the expand all button is visible", () => {
   OneMacFAQPage.verifyExpandAllBtnExists();
 });

--- a/tests/cypress/package-lock.json
+++ b/tests/cypress/package-lock.json
@@ -641,9 +641,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.6.tgz",
-      "integrity": "sha512-muPzBqXJKCbMYoNbb1JpZh/ynl0xS6/+pLjrofcR3Nad82SbsCogYzUE6Aq9QT3cLP0jR/IVK/NHC9b90mSHtg==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.8.tgz",
+      "integrity": "sha512-31E2lxlGM1KEfivQl8Yf5aYU/mflz9g06H6S15ITUFQueMFtFjESRMoDSkvMo8thYvLBax+VKTPlpnx+sPicOA==",
       "cpu": [
         "arm"
       ],
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.6.tgz",
-      "integrity": "sha512-KQ/hbe9SJvIJ4sR+2PcZ41IBV+LPJyYp6V1K1P1xcMRup9iYsBoQn4MzE3mhMLOld27Au2eDcLlIREeKGUXpHQ==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.8.tgz",
+      "integrity": "sha512-B8JbS61bEunhfx8kasogFENgQfr/dIp+ggYXwTqdbMAgGDhRa3AaPpQMuQU0rNxDLECj6FhDzk1cF9WHMVwrtA==",
       "cpu": [
         "arm64"
       ],
@@ -673,9 +673,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.6.tgz",
-      "integrity": "sha512-VVJVZQ7p5BBOKoNxd0Ly3xUM78Y4DyOoFKdkdAe2m11jbh0LEU4bPles4e/72EMl4tapko8o915UalN/5zhspg==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.8.tgz",
+      "integrity": "sha512-rdqqYfRIn4jWOp+lzQttYMa2Xar3OK9Yt2fhOhzFXqg0rVWEfSclJvZq5fZslnz6ypHvVf3CT7qyf0A5pM682A==",
       "cpu": [
         "x64"
       ],
@@ -689,9 +689,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.6.tgz",
-      "integrity": "sha512-91LoRp/uZAKx6ESNspL3I46ypwzdqyDLXZH7x2QYCLgtnaU08+AXEbabY2yExIz03/am0DivsTtbdxzGejfXpA==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.8.tgz",
+      "integrity": "sha512-RQw9DemMbIq35Bprbboyf8SmOr4UXsRVxJ97LgB55VKKeJOOdvsIPy0nFyF2l8U+h4PtBx/1kRf0BelOYCiQcw==",
       "cpu": [
         "arm64"
       ],
@@ -705,9 +705,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.6.tgz",
-      "integrity": "sha512-QCGHw770ubjBU1J3ZkFJh671MFajGTYMZumPs9E/rqU52md6lIil97BR0CbPq6U+vTh3xnTNDHKRdR8ggHnmxQ==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.8.tgz",
+      "integrity": "sha512-3sur80OT9YdeZwIVgERAysAbwncom7b4bCI2XKLjMfPymTud7e/oY4y+ci1XVp5TfQp/bppn7xLw1n/oSQY3/Q==",
       "cpu": [
         "x64"
       ],
@@ -721,9 +721,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.6.tgz",
-      "integrity": "sha512-J53d0jGsDcLzWk9d9SPmlyF+wzVxjXpOH7jVW5ae7PvrDst4kiAz6sX+E8btz0GB6oH12zC+aHRD945jdjF2Vg==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.8.tgz",
+      "integrity": "sha512-WAnPJSDattvS/XtPCTj1tPoTxERjcTpH6HsMr6ujTT+X6rylVe8ggxk8pVxzf5U1wh5sPODpawNicF5ta/9Tmw==",
       "cpu": [
         "arm64"
       ],
@@ -737,9 +737,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.6.tgz",
-      "integrity": "sha512-hn9qvkjHSIB5Z9JgCCjED6YYVGCNpqB7dEGavBdG6EjBD8S/UcNUIlGcB35NCkMETkdYwfZSvD9VoDJX6VeUVA==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.8.tgz",
+      "integrity": "sha512-ICvZyOplIjmmhjd6mxi+zxSdpPTKFfyPPQMQTK/w+8eNK6WV01AjIztJALDtwNNfFhfZLux0tZLC+U9nSyA5Zg==",
       "cpu": [
         "x64"
       ],
@@ -753,9 +753,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.6.tgz",
-      "integrity": "sha512-G8IR5zFgpXad/Zp7gr7ZyTKyqZuThU6z1JjmRyN1vSF8j0bOlGzUwFSMTbctLAdd7QHpeyu0cRiuKrqK1ZTwvQ==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.8.tgz",
+      "integrity": "sha512-H4vmI5PYqSvosPaTJuEppU9oz1dq2A7Mr2vyg5TF9Ga+3+MGgBdGzcyBP7qK9MrwFQZlvNyJrvz6GuCaj3OukQ==",
       "cpu": [
         "arm"
       ],
@@ -769,9 +769,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.6.tgz",
-      "integrity": "sha512-HQCOrk9XlH3KngASLaBfHpcoYEGUt829A9MyxaI8RMkfRA8SakG6YQEITAuwmtzFdEu5GU4eyhKcpv27dFaOBg==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.8.tgz",
+      "integrity": "sha512-z1zMZivxDLHWnyGOctT9JP70h0beY54xDDDJt4VpTX+iwA77IFsE1vCXWmprajJGa+ZYSqkSbRQ4eyLCpCmiCQ==",
       "cpu": [
         "arm64"
       ],
@@ -785,9 +785,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.6.tgz",
-      "integrity": "sha512-22eOR08zL/OXkmEhxOfshfOGo8P69k8oKHkwkDrUlcB12S/sw/+COM4PhAPT0cAYW/gpqY2uXp3TpjQVJitz7w==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.8.tgz",
+      "integrity": "sha512-1a8suQiFJmZz1khm/rDglOc8lavtzEMRo0v6WhPgxkrjcU0LkHj+TwBrALwoz/OtMExvsqbbMI0ChyelKabSvQ==",
       "cpu": [
         "ia32"
       ],
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.6.tgz",
-      "integrity": "sha512-82RvaYAh/SUJyjWA8jDpyZCHQjmEggL//sC7F3VKYcBMumQjUL3C5WDl/tJpEiKtt7XrWmgjaLkrk205zfvwTA==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.8.tgz",
+      "integrity": "sha512-fHZWS2JJxnXt1uYJsDv9+b60WCc2RlvVAy1F76qOLtXRO+H4mjt3Tr6MJ5l7Q78X8KgCFudnTuiQRBhULUyBKQ==",
       "cpu": [
         "loong64"
       ],
@@ -817,9 +817,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.6.tgz",
-      "integrity": "sha512-8tvnwyYJpR618vboIv2l8tK2SuK/RqUIGMfMENkeDGo3hsEIrpGldMGYFcWxWeEILe5Fi72zoXLmhZ7PR23oQA==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.8.tgz",
+      "integrity": "sha512-Wy/z0EL5qZYLX66dVnEg9riiwls5IYnziwuju2oUiuxVc+/edvqXa04qNtbrs0Ukatg5HEzqT94Zs7J207dN5Q==",
       "cpu": [
         "mips64el"
       ],
@@ -833,9 +833,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.6.tgz",
-      "integrity": "sha512-Qt+D7xiPajxVNk5tQiEJwhmarNnLPdjXAoA5uWMpbfStZB0+YU6a3CtbWYSy+sgAsnyx4IGZjWsTzBzrvg/fMA==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.8.tgz",
+      "integrity": "sha512-ETaW6245wK23YIEufhMQ3HSeHO7NgsLx8gygBVldRHKhOlD1oNeNy/P67mIh1zPn2Hr2HLieQrt6tWrVwuqrxg==",
       "cpu": [
         "ppc64"
       ],
@@ -849,9 +849,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.6.tgz",
-      "integrity": "sha512-lxRdk0iJ9CWYDH1Wpnnnc640ajF4RmQ+w6oHFZmAIYu577meE9Ka/DCtpOrwr9McMY11ocbp4jirgGgCi7Ls/g==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.8.tgz",
+      "integrity": "sha512-T2DRQk55SgoleTP+DtPlMrxi/5r9AeFgkhkZ/B0ap99zmxtxdOixOMI570VjdRCs9pE4Wdkz7JYrsPvsl7eESg==",
       "cpu": [
         "riscv64"
       ],
@@ -865,9 +865,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.6.tgz",
-      "integrity": "sha512-MopyYV39vnfuykHanRWHGRcRC3AwU7b0QY4TI8ISLfAGfK+tMkXyFuyT1epw/lM0pflQlS53JoD22yN83DHZgA==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.8.tgz",
+      "integrity": "sha512-NPxbdmmo3Bk7mbNeHmcCd7R7fptJaczPYBaELk6NcXxy7HLNyWwCyDJ/Xx+/YcNH7Im5dHdx9gZ5xIwyliQCbg==",
       "cpu": [
         "s390x"
       ],
@@ -881,9 +881,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.6.tgz",
-      "integrity": "sha512-UWcieaBzsN8WYbzFF5Jq7QULETPcQvlX7KL4xWGIB54OknXJjBO37sPqk7N82WU13JGWvmDzFBi1weVBajPovg==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.8.tgz",
+      "integrity": "sha512-lytMAVOM3b1gPypL2TRmZ5rnXl7+6IIk8uB3eLsV1JwcizuolblXRrc5ShPrO9ls/b+RTp+E6gbsuLWHWi2zGg==",
       "cpu": [
         "x64"
       ],
@@ -897,9 +897,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.6.tgz",
-      "integrity": "sha512-EpWiLX0fzvZn1wxtLxZrEW+oQED9Pwpnh+w4Ffv8ZLuMhUoqR9q9rL4+qHW8F4Mg5oQEKxAoT0G+8JYNqCiR6g==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.8.tgz",
+      "integrity": "sha512-hvWVo2VsXz/8NVt1UhLzxwAfo5sioj92uo0bCfLibB0xlOmimU/DeAEsQILlBQvkhrGjamP0/el5HU76HAitGw==",
       "cpu": [
         "x64"
       ],
@@ -913,9 +913,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.6.tgz",
-      "integrity": "sha512-fFqTVEktM1PGs2sLKH4M5mhAVEzGpeZJuasAMRnvDZNCV0Cjvm1Hu35moL2vC0DOrAQjNTvj4zWrol/lwQ8Deg==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.8.tgz",
+      "integrity": "sha512-/7Y7u77rdvmGTxR83PgaSvSBJCC2L3Kb1M/+dmSIvRvQPXXCuC97QAwMugBNG0yGcbEGfFBH7ojPzAOxfGNkwQ==",
       "cpu": [
         "x64"
       ],
@@ -929,9 +929,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.6.tgz",
-      "integrity": "sha512-M+XIAnBpaNvaVAhbe3uBXtgWyWynSdlww/JNZws0FlMPSBy+EpatPXNIlKAdtbFVII9OpX91ZfMb17TU3JKTBA==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.8.tgz",
+      "integrity": "sha512-9Lc4s7Oi98GqFA4HzA/W2JHIYfnXbUYgekUP/Sm4BG9sfLjyv6GKKHKKVs83SMicBF2JwAX6A1PuOLMqpD001w==",
       "cpu": [
         "x64"
       ],
@@ -945,9 +945,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.6.tgz",
-      "integrity": "sha512-2DchFXn7vp/B6Tc2eKdTsLzE0ygqKkNUhUBCNtMx2Llk4POIVMUq5rUYjdcedFlGLeRe1uLCpVvCmE+G8XYybA==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.8.tgz",
+      "integrity": "sha512-rq6WzBGjSzihI9deW3fC2Gqiak68+b7qo5/3kmB6Gvbh/NYPA0sJhrnp7wgV4bNwjqM+R2AApXGxMO7ZoGhIJg==",
       "cpu": [
         "arm64"
       ],
@@ -961,9 +961,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.6.tgz",
-      "integrity": "sha512-PBo/HPDQllyWdjwAVX+Gl2hH0dfBydL97BAH/grHKC8fubqp02aL4S63otZ25q3sBdINtOBbz1qTZQfXbP4VBg==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.8.tgz",
+      "integrity": "sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw==",
       "cpu": [
         "ia32"
       ],
@@ -977,9 +977,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.6.tgz",
-      "integrity": "sha512-OE7yIdbDif2kKfrGa+V0vx/B3FJv2L4KnIiLlvtibPyO9UkgO3rzYE0HhpREo2vmJ1Ixq1zwm9/0er+3VOSZJA==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.8.tgz",
+      "integrity": "sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==",
       "cpu": [
         "x64"
       ],
@@ -1079,9 +1079,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.18.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.10.tgz",
-      "integrity": "sha512-luANqZxPmjTll8bduz4ACs/lNTCLuWssCyjqTY9yLdsv1xnViQp3ISKwsEWOIecO13JWUqjVdig/Vjjc09o8uA==",
+      "version": "18.18.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.13.tgz",
+      "integrity": "sha512-vXYZGRrSCreZmq1rEjMRLXJhiy8MrIeVasx+PCVlP414N7CJLHnMf+juVvjdprHyH+XRy3zKZLHeNueOpJCn0g==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1094,9 +1094,9 @@
       "dev": true
     },
     "node_modules/@types/sizzle": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.6.tgz",
-      "integrity": "sha512-m04Om5Gz6kbjUwAQ7XJJQ30OdEFsSmAVsvn4NYwcTRyMVpKKa1aPuESw1n2CxS5fYkOQv3nHgDKeNa8e76fUkw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
+      "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
       "dev": true
     },
     "node_modules/@types/uuid": {
@@ -1869,9 +1869,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.5.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.5.1.tgz",
-      "integrity": "sha512-yqLViT0D/lPI8Kkm7ciF/x/DCK/H/DnogdGyiTnQgX4OVR2aM30PtK+kvklTOD1u3TuItiD9wUQAF8EYWtyZug==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.0.tgz",
+      "integrity": "sha512-quIsnFmtj4dBUEJYU4OH0H12bABJpSujvWexC24Ju1gTlKMJbeT6tTO0vh7WNfiBPPjoIXLN+OUqVtiKFs6SGw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2125,9 +2125,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.6.tgz",
-      "integrity": "sha512-Xl7dntjA2OEIvpr9j0DVxxnog2fyTGnyVoQXAMQI6eR3mf9zCQds7VIKUDCotDgE/p4ncTgeRqgX8t5d6oP4Gw==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.8.tgz",
+      "integrity": "sha512-l7iffQpT2OrZfH2rXIp7/FkmaeZM0vxbxN9KfiCwGYuZqzMg/JdvX26R31Zxn/Pxvsrg3Y9N6XTcnknqDyyv4w==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -2137,28 +2137,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.19.6",
-        "@esbuild/android-arm64": "0.19.6",
-        "@esbuild/android-x64": "0.19.6",
-        "@esbuild/darwin-arm64": "0.19.6",
-        "@esbuild/darwin-x64": "0.19.6",
-        "@esbuild/freebsd-arm64": "0.19.6",
-        "@esbuild/freebsd-x64": "0.19.6",
-        "@esbuild/linux-arm": "0.19.6",
-        "@esbuild/linux-arm64": "0.19.6",
-        "@esbuild/linux-ia32": "0.19.6",
-        "@esbuild/linux-loong64": "0.19.6",
-        "@esbuild/linux-mips64el": "0.19.6",
-        "@esbuild/linux-ppc64": "0.19.6",
-        "@esbuild/linux-riscv64": "0.19.6",
-        "@esbuild/linux-s390x": "0.19.6",
-        "@esbuild/linux-x64": "0.19.6",
-        "@esbuild/netbsd-x64": "0.19.6",
-        "@esbuild/openbsd-x64": "0.19.6",
-        "@esbuild/sunos-x64": "0.19.6",
-        "@esbuild/win32-arm64": "0.19.6",
-        "@esbuild/win32-ia32": "0.19.6",
-        "@esbuild/win32-x64": "0.19.6"
+        "@esbuild/android-arm": "0.19.8",
+        "@esbuild/android-arm64": "0.19.8",
+        "@esbuild/android-x64": "0.19.8",
+        "@esbuild/darwin-arm64": "0.19.8",
+        "@esbuild/darwin-x64": "0.19.8",
+        "@esbuild/freebsd-arm64": "0.19.8",
+        "@esbuild/freebsd-x64": "0.19.8",
+        "@esbuild/linux-arm": "0.19.8",
+        "@esbuild/linux-arm64": "0.19.8",
+        "@esbuild/linux-ia32": "0.19.8",
+        "@esbuild/linux-loong64": "0.19.8",
+        "@esbuild/linux-mips64el": "0.19.8",
+        "@esbuild/linux-ppc64": "0.19.8",
+        "@esbuild/linux-riscv64": "0.19.8",
+        "@esbuild/linux-s390x": "0.19.8",
+        "@esbuild/linux-x64": "0.19.8",
+        "@esbuild/netbsd-x64": "0.19.8",
+        "@esbuild/openbsd-x64": "0.19.8",
+        "@esbuild/sunos-x64": "0.19.8",
+        "@esbuild/win32-arm64": "0.19.8",
+        "@esbuild/win32-ia32": "0.19.8",
+        "@esbuild/win32-x64": "0.19.8"
       }
     },
     "node_modules/esbuild-android-64": {
@@ -3553,9 +3553,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.3.tgz",
-      "integrity": "sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -51,8 +51,10 @@ const initialSubmissionDateDatePickerFilter =
   "#submissionTimestamp-date-filter";
 const formalRAIReceivedDateFilterDropdown =
   "#latestRaiResponseTimestamp-button";
+const finalDispositionDateFilterDropdown = "#finalDispositionDate-button";
 const formalRAIReceivedDatePickerFilter =
   "#latestRaiResponseTimestamp-date-filter";
+const finalDispositionDatePickerFilter = "#finalDispositionDate-date-filter";
 //Element is Xpath use cy.xpath instead of cy.get
 const thisQuarterDatePickerBtn = "//button[contains(text(),'This Quarter')]";
 //Element is Xpath use cy.xpath instead of cy.get
@@ -121,6 +123,8 @@ const checkBoxSubmittedBy = "//span[contains(text(),'Submitted By')]";
 //Element is Xpath use cy.xpath instead of cy.get
 const checkBoxType = "//span[contains(text(),'Type')]";
 const checkboxCPOCName = "//span[contains(text(),'CPOC Name')]";
+const checkboxfinalDispositionDate =
+  "//span[contains(text(),'Final Disposition')]";
 const IDNumberColumn = "#componentIdColHeader";
 const typeColumn = "#componentTypeColHeader";
 const statusColumn = "#packageStatusColHeader";
@@ -129,6 +133,7 @@ const submittedByColumn = "#submitterColHeader";
 const actionsColumn = "#packageActionsColHeader";
 const formalRAIReceivedColumn = "#latestRaiResponseTimestampColHeader";
 const cPOCNameColumn = "#cpocNameColHeader";
+const finalDispositionColumn = "#finalDispositionDateColHeader";
 const packageRowOneType = "#componentType-0";
 const packageRowOneState = "#territory-0";
 //first obj is a header and second obj is row if there are results
@@ -312,6 +317,13 @@ export class oneMacPackagePage {
     cy.get(formalRAIReceivedDateFilterDropdown).wait(1000);
     cy.get(formalRAIReceivedDateFilterDropdown).click();
   }
+  verifyFinalDispositionDateFilterDropdownExists() {
+    cy.get(finalDispositionDateFilterDropdown).should("be.visible");
+  }
+  clickOnFinalDispositionDateFilterDropdownDropDown() {
+    cy.get(finalDispositionDateFilterDropdown).wait(1000);
+    cy.get(finalDispositionDateFilterDropdown).click();
+  }
   verifyNinetiethDayNACheckboxExists() {
     cy.xpath(ninetiethDayNACheckbox).should("exist");
   }
@@ -343,6 +355,10 @@ export class oneMacPackagePage {
   clickOnFormalRAIReceivedDatePickerFilter() {
     cy.get(formalRAIReceivedDatePickerFilter).wait(1000);
     cy.get(formalRAIReceivedDatePickerFilter).last().click();
+  }
+  clickOnFinalDispositionDatePickerFilter() {
+    cy.get(finalDispositionDatePickerFilter).wait(1000);
+    cy.get(finalDispositionDatePickerFilter).last().click();
   }
   clickOnThisQuarterDatePickerBtn() {
     cy.xpath(thisQuarterDatePickerBtn).click();
@@ -529,6 +545,12 @@ export class oneMacPackagePage {
   clickCPOCNameCheckBox() {
     cy.xpath(checkboxCPOCName).click();
   }
+  verifyFinalDispositionCheckBoxExists() {
+    cy.xpath(checkboxfinalDispositionDate).should("be.visible");
+  }
+  clickFinalDispositionDateCheckBox() {
+    cy.xpath(checkboxfinalDispositionDate).click();
+  }
   verifyIDNumberColumnExists() {
     cy.get(IDNumberColumn).should("be.visible");
   }
@@ -578,6 +600,12 @@ export class oneMacPackagePage {
   }
   verifyCPOCNameColumnDoesNotExist() {
     cy.get(cPOCNameColumn).should("not.exist");
+  }
+  verifyFinalDispositionColumnExists() {
+    cy.get(finalDispositionColumn).should("be.visible");
+  }
+  verifyFinalDispositionColumnDoesNotExist() {
+    cy.get(finalDispositionColumn).should("not.exist");
   }
   verifyactionsColumnDoesNotExist() {
     cy.get(actionsColumn).should("not.exist");


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-26321
Endpoint: See github-actions bot comment

### Details
CMS has asked that Package Withdrawn date get added to the dashboard for use with filters and reports.  We discovered that "Final Disposition" date is the Package Withdrawn date when the package is in Withdrawn status, so decided to add that column to the dashboard instead.

### Changes
- Because of weird date conversion issues, see "Implementation Notes," added the finalDispositionTimestamp to the package items and added enough milliseconds to be on the correct date in the eastern timezone.
- Added finalDispositionTimestamp to the dashboard as a hidden column.
- added filter details to make filters work as dictated

### Implementation Notes
The date being used is the SEA Tool STATUS_DATE on the STATE_PLAN record.  Now... that date is captured in the SEA Tool application as a mm-dd-yyyy date and sent to us as a timestamp... however, the timestamp is for GMT, so in any date conversion that uses local timezone, it is a day off.  We get around this in other places by converting the date on the back end (which uses GMT), but in order to use the date filter widget, we need a timestamp, so I've added enough milliseconds to the "timestamp" to have it be on the correct date in either GMT or Eastern.

### Test Plan
1. Login as a state user
2. Navigate to Dashboard
3. Verify Final Disposition is not a default column
4. Click "Show/Hide Columns"
5. Select Final Disposition
6. Verify the column is added to the dashboard and contains the correct value (can compare to details page)
7. Verify filters work as expected
8. Verify saving of filters works as expected
9. Verify exports are correct
10. Do the same tests with a CMS user
