### PR TITLE
Hotfix fix: Dev branch hotfixed waiver renewal 2nd clock to wrong place

### DIFF
--- a/services/common/type/waiverRenewal.js
+++ b/services/common/type/waiverRenewal.js
@@ -38,6 +38,11 @@ export const waiverRenewal = {
     "parentId",
     "parentType",
   ],
+  secondClockStatuses: [
+    "Pending",
+    "Pending - Concurrence",
+    "Pending - Approval",
+  ],
 };
 
 export const waiverRenewalB4 = {
@@ -62,10 +67,5 @@ export const waiverRenewalB = {
     waiverBIndependentAssessment,
     tribalConsultation,
     other,
-  ],
-  secondClockStatuses: [
-    "Pending",
-    "Pending - Concurrence",
-    "Pending - Approval",
   ],
 };


### PR DESCRIPTION
Hot Fix fix
Endpoint: See github-actions bot comment

### Details
The hotfix to VAL was done correctly, but when the same work was added to DEV branch, it got added to the incorrect object (waiver renewal B4 instead of the parent waiver renewal)

### Changes
- moved secondClockStatuses to the "parent" waiverRenewal object

### Test Plan
1. Login as a CMS user
2. Select a Waiver renewal of each authority that has the correct alignment to have the 2nd clock message on the details page.
3. Verify that the second clock message is visible on the page.
4. Bonus: Verify that CHIP SPAs do not have 2nd clock messages
