### PR TITLE
update faq for rai response q&a for medicaid spa, chip spa, and waivers

### DIFF
--- a/services/ui-src/src/libs/faq/faqContent.tsx
+++ b/services/ui-src/src/libs/faq/faqContent.tsx
@@ -509,6 +509,98 @@ export const oneMACFAQContent: FAQContent[] = [
           </p>
         ),
       },
+      {
+        anchorText: "medicaid-spa-rai-response",
+        isOpen: false,
+        question:
+          "How do I submit a Formal Request for Additional Information (RAI) Response for a  Medicaid SPA?",
+        answerJSX: (
+          <div>
+            <p>
+              When necessary, states will receive an RAI via email from CMS.
+            </p>
+            <ul>
+              <li>The state will respond to the RAI through OneMAC.</li>
+              <li>
+                A Request for Additional Information (RAI) stops the 90-day
+                clock, is a formal request for additional information from CMS.
+              </li>
+              <li>
+                Packages pending an official RAI response from the state will
+                have a Status of <b>RAI Issued</b>.
+              </li>
+            </ul>
+            <p>
+              To respond to a Medicaid SPA RAI, select the SPA Tab view from the
+              Package Dashboard.
+            </p>
+            <ul>
+              <li>
+                Select the link to the SPA ID. Packages which are in need of an
+                RAI response from the state will have a Status of{" "}
+                <b>RAI Issued</b>.
+              </li>
+              <li>
+                Then, under Package Actions, select the Respond to RAI link.
+              </li>
+              <li>
+                After attaching any required files, you may include additional
+                notes prior to clicking on the submit button.
+              </li>
+              <li>
+                Check your entries, as you cannot edit the submission after you
+                select Submit.
+              </li>
+            </ul>
+          </div>
+        ),
+      },
+      {
+        anchorText: "chip-spa-rai-response",
+        isOpen: false,
+        question:
+          "How do I submit a Formal Request for Additional Information (RAI) Response for a CHIP SPA?",
+        answerJSX: (
+          <div>
+            <p>
+              When necessary, states will receive an RAI via email from CMS.
+            </p>
+            <ul>
+              <li>The state will respond to the RAI through OneMAC.</li>
+              <li>
+                A Request for Additional Information (RAI) stops the 90-day
+                clock, is a formal request for additional information from CMS.
+              </li>
+              <li>
+                Packages pending an official RAI response from the state will
+                have a Status of <b>RAI Issued</b>.
+              </li>
+            </ul>
+            <p>
+              To respond to a CHIP SPA RAI, select the SPA Tab view from the
+              Package Dashboard.
+            </p>
+            <ul>
+              <li>
+                Select the link to the SPA ID. Packages which are in need of an
+                RAI response from the state will have a Status of{" "}
+                <b>RAI Issued</b>.
+              </li>
+              <li>
+                Then, under Package Actions, select the Respond to RAI link.
+              </li>
+              <li>
+                After attaching any required files, you may include additional
+                notes prior to clicking on the submit button.
+              </li>
+              <li>
+                Check your entries, as you cannot edit the submission after you
+                select Submit.
+              </li>
+            </ul>
+          </div>
+        ),
+      },
     ],
   },
   {
@@ -932,6 +1024,52 @@ export const oneMACFAQContent: FAQContent[] = [
               </tbody>
             </table>
           </>
+        ),
+      },
+      {
+        anchorText: "waiver-rai-response",
+        isOpen: false,
+        question:
+          "How do I submit a Formal Request for Additional Information (RAI) Response for a Waiver?",
+        answerJSX: (
+          <div>
+            <p>
+              When necessary, states will receive an RAI via email from CMS.
+            </p>
+            <ul>
+              <li>The state will respond to the RAI through OneMAC.</li>
+              <li>
+                A Request for Additional Information (RAI) stops the 90-day
+                clock, is a formal request for additional information from CMS.
+              </li>
+              <li>
+                Packages pending an official RAI response from the state will
+                have a Status of <b>RAI Issued</b>.
+              </li>
+            </ul>
+            <p>
+              To respond to a Waiver RAI, select the Waiver Tab view from the
+              Package Dashboard.
+            </p>
+            <ul>
+              <li>
+                Select the link to the Waiver ID. Packages which are in need of
+                an RAI response from the state will have a Status of{" "}
+                <b>RAI Issued</b>.
+              </li>
+              <li>
+                Then, under Package Actions, select the Respond to RAI link.
+              </li>
+              <li>
+                After attaching any required files, you may include additional
+                notes prior to clicking on the submit button.
+              </li>
+              <li>
+                Check your entries, as you cannot edit the submission after you
+                select Submit.
+              </li>
+            </ul>
+          </div>
         ),
       },
     ],


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-26281
Endpoint: See github-actions bot comment

### Details

Add FAQ question/answers for RAI Response. This includes 3 new q/a sections for medicaid spa, chip spa, and waiver.

### Changes

Added new sections to faqContent.tsx
ACs did not mention where in each section to add the new questions so I elected to add at the bottom of their respective sections.

### Test Plan

1. Navigate to FAQ page and verify new section text
