### PR TITLE
PI2 26711: Can't take withdraw RAI action on another RAI in the same package

### DIFF
--- a/services/app-api/form/disableRaiWithdraw.js
+++ b/services/app-api/form/disableRaiWithdraw.js
@@ -63,8 +63,8 @@ async function getRecordsByGSI1Keys(gsi1pk, gsi1sk) {
 
   try {
     const result = await dynamoDb.query(params);
-    const sortedRecords = result.Items.sort((a, b) =>
-      a.submissionTimestamp.localeCompare(b.submissionTimestamp)
+    const sortedRecords = result.Items.sort(
+      (a, b) => b.submissionTimestamp - a.submissionTimestamp
     );
     return sortedRecords;
   } catch (error) {

--- a/services/app-api/form/enableRaiWithdraw.js
+++ b/services/app-api/form/enableRaiWithdraw.js
@@ -65,7 +65,7 @@ async function getRecordsByGSI1Keys(gsi1pk, gsi1sk) {
     const result = await dynamoDb.query(params);
     console.log("the result Items: ", result.Items);
     const sortedRecords = result.Items.sort(
-      (a, b) => a.submissionTimestamp > b.submissionTimestamp
+      (a, b) => a.submissionTimestamp < b.submissionTimestamp
     );
     console.log("the items sorted are: ", sortedRecords);
     return sortedRecords;

--- a/services/app-api/form/enableRaiWithdraw.js
+++ b/services/app-api/form/enableRaiWithdraw.js
@@ -63,9 +63,11 @@ async function getRecordsByGSI1Keys(gsi1pk, gsi1sk) {
 
   try {
     const result = await dynamoDb.query(params);
-    const sortedRecords = result.Items.sort((a, b) =>
-      a.submissionTimestamp.localeCompare(b.submissionTimestamp)
+    console.log("the result Items: ", result.Items);
+    const sortedRecords = result.Items.sort(
+      (a, b) => a.submissionTimestamp > b.submissionTimestamp
     );
+    console.log("the items sorted are: ", sortedRecords);
     return sortedRecords;
   } catch (error) {
     console.error("Error retrieving records:", error);

--- a/services/app-api/form/enableRaiWithdraw.js
+++ b/services/app-api/form/enableRaiWithdraw.js
@@ -65,7 +65,7 @@ async function getRecordsByGSI1Keys(gsi1pk, gsi1sk) {
     const result = await dynamoDb.query(params);
     console.log("the result Items: ", result.Items);
     const sortedRecords = result.Items.sort(
-      (a, b) => a.submissionTimestamp < b.submissionTimestamp
+      (a, b) => b.submissionTimestamp - a.submissionTimestamp
     );
     console.log("the items sorted are: ", sortedRecords);
     return sortedRecords;

--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -307,14 +307,16 @@ export const buildAnyPackage = async (packageId, config) => {
 
     putParams.Item?.reverseChrono.sort((a, b) => b.timestamp - a.timestamp);
 
-    // if the most recent OneMAC event is an enable withdraw RAI Response,
+    // if the most recent RAI Response OneMAC event is an enable withdraw RAI Response,
     // then set sub status to "Withdraw RAI Enabled"
     // and freeze status to pending
+    const raiResponses = putParams.Item?.reverseChrono.filter(
+      (omEvent) => omEvent.type === "Formal RAI Response"
+    );
     if (
-      Array.isArray(putParams.Item?.reverseChrono) &&
-      putParams.Item.reverseChrono.length > 0 &&
-      putParams.Item.reverseChrono[0].currentStatus ===
-        ONEMAC_STATUS.WITHDRAW_RAI_ENABLED
+      Array.isArray(raiResponses) &&
+      raiResponses.length > 0 &&
+      raiResponses[0].currentStatus === ONEMAC_STATUS.WITHDRAW_RAI_ENABLED
     ) {
       putParams.Item.currentStatus = ONEMAC_STATUS.PENDING;
       putParams.Item.subStatus = ONEMAC_STATUS.WITHDRAW_RAI_ENABLED;

--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -307,16 +307,14 @@ export const buildAnyPackage = async (packageId, config) => {
 
     putParams.Item?.reverseChrono.sort((a, b) => b.timestamp - a.timestamp);
 
-    // if the most recent RAI Response OneMAC event is an enable withdraw RAI Response,
+    // if the most recent OneMAC event is an enable withdraw RAI Response,
     // then set sub status to "Withdraw RAI Enabled"
     // and freeze status to pending
-    const raiResponses = putParams.Item?.reverseChrono.filter(
-      (omEvent) => omEvent.type === "Formal RAI Response"
-    );
     if (
-      Array.isArray(raiResponses) &&
-      raiResponses.length > 0 &&
-      raiResponses[0].currentStatus === ONEMAC_STATUS.WITHDRAW_RAI_ENABLED
+      Array.isArray(putParams.Item?.reverseChrono) &&
+      putParams.Item.reverseChrono.length > 0 &&
+      putParams.Item.reverseChrono[0].currentStatus ===
+        ONEMAC_STATUS.WITHDRAW_RAI_ENABLED
     ) {
       putParams.Item.currentStatus = ONEMAC_STATUS.PENDING;
       putParams.Item.subStatus = ONEMAC_STATUS.WITHDRAW_RAI_ENABLED;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-26711
Endpoint: See github-actions bot comment

NOTE: I named the branch for the other story... which we probably should not do at this time...

### Details
There was a bug in the enableRAIWithdraw function that was preventing the handling of multiple RAIs in a package.

### Changes
- changed the RAI Response sorting from String based to number based

### Test Plan
1. See story!

