### PR TITLE
PI2 26710 Option 1: Remove Withdraw Package action from packages with RAI Response Withdraw enabled to prevent erroneous submissions

### DIFF
--- a/services/app-api/utils/actionDelegate.js
+++ b/services/app-api/utils/actionDelegate.js
@@ -9,7 +9,10 @@ function getDefaultActions(
   const actions = [];
   switch (packageStatus) {
     case Workflow.ONEMAC_STATUS.PENDING:
-      if (userRole.canAccessForms)
+      if (
+        userRole.canAccessForms &&
+        packageSubStatus !== Workflow.ONEMAC_STATUS.WITHDRAW_RAI_ENABLED
+      )
         actions.push(Workflow.PACKAGE_ACTION.WITHDRAW);
       if (
         userRole.isCMSUser &&

--- a/services/app-api/utils/actionDelegate.test.js
+++ b/services/app-api/utils/actionDelegate.test.js
@@ -96,10 +96,11 @@ describe("getActionsForPackage", () => {
       formSource
     );
 
-    expect(actions).toEqual([
-      "Withdraw Package",
-      "Withdraw Formal RAI Response",
-    ]);
+    // expect(actions).toEqual([
+    //   "Withdraw Package",
+    //   "Withdraw Formal RAI Response",
+    // ]);
+    expect(actions).toEqual(["Withdraw Formal RAI Response"]);
   });
 
   it("returns correct actions for medicaid spa with Pending - Approval status", () => {

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -63,6 +63,7 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
   const [alertCode, setAlertCode] = useState(RESPONSE_CODE.NONE);
   const { activeTerritories, confirmAction } = useAppContext() ?? {};
   const location = useLocation<FormLocationState>();
+  console.log("location state: ", location);
 
   //Reference to the File Uploader.
   const uploader = useRef<FileUploader>(null);

--- a/services/ui-src/src/page/medicaid-spa/MedicaidSpaWithdraw.tsx
+++ b/services/ui-src/src/page/medicaid-spa/MedicaidSpaWithdraw.tsx
@@ -13,6 +13,8 @@ export const medicaidSpaWithdrawInfo: OneMACFormConfig = {
 };
 
 const MedicaidSpaWithdraw: FC = () => {
+  console.log("Form Into:", medicaidSpaWithdrawInfo);
+
   return <OneMACForm formConfig={medicaidSpaWithdrawInfo} />;
 };
 

--- a/services/ui-src/src/page/withdraw-rai/WithdrawRAIForm.tsx
+++ b/services/ui-src/src/page/withdraw-rai/WithdrawRAIForm.tsx
@@ -30,6 +30,7 @@ export const withdrawRAIFormInfo: OneMACFormConfig = {
 };
 
 const WithdrawRAIForm: FC = () => {
+  console.log("Form Into:", withdrawRAIFormInfo);
   return <OneMACForm formConfig={withdrawRAIFormInfo} />;
 };
 


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-26710
Endpoint: See github-actions bot comment

### Details
Can prevent erroneous Withdraw Package submissions by removing it as an available action when the package is in the Formal RAI Response Withdraw Enabled state.

### Changes
- removed the Withdraw Package action from packages with the subStatus of "Formal RAI Response Withdraw Enabled"
- updated tests to match/pass

### Test Plan
1. login as a submitting user
2. verify that "Withdraw Package" is not an available option on the dashboard for packages in "Formal RAI Response WIthdraw Enabled" subStatus
3. verify that "Withdraw Package" is not an available option on the package details page for packages in "Formal RAI Response WIthdraw Enabled" subStatus

