### PR TITLE
Update serverless.yml

### DIFF
--- a/services/app-api/resources/api-gateway.yml
+++ b/services/app-api/resources/api-gateway.yml
@@ -14,6 +14,13 @@ Resources:
       ResponseParameters:
         gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
         gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.X-Content-Type-Options: "'nosniff'"
+        ResponseType: DEFAULT_4XX
+        RestApiId:
+          Ref: 'ApiGatewayRestApi'
       ResponseType: DEFAULT_5XX
       RestApiId:
         Ref: "ApiGatewayRestApi"

--- a/services/app-api/resources/api-gateway.yml
+++ b/services/app-api/resources/api-gateway.yml
@@ -5,6 +5,7 @@ Resources:
       ResponseParameters:
         gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
         gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        gatewayresponse.header.X-Content-Type-Options: "'nosniff'"
       ResponseType: DEFAULT_4XX
       RestApiId:
         Ref: "ApiGatewayRestApi"
@@ -14,13 +15,6 @@ Resources:
       ResponseParameters:
         gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
         gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
-        Type: 'AWS::ApiGateway::GatewayResponse'
-      Properties:
-        ResponseParameters:
-          gatewayresponse.header.X-Content-Type-Options: "'nosniff'"
-        ResponseType: DEFAULT_4XX
-        RestApiId:
-          Ref: 'ApiGatewayRestApi'
       ResponseType: DEFAULT_5XX
       RestApiId:
         Ref: "ApiGatewayRestApi"

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -235,7 +235,7 @@ resources:
             headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload'};
             headers['x-frame-options'] = { value: 'SAMEORIGIN'};
             headers['x-frame-options'] = { value: 'DENY'};
-            headers['x-content-type-options'] = { value: 'NOSNIFF' };
+            headers['x-content-type-options'] = { value: 'nosniff' };
             return response;
           }
         FunctionConfig:


### PR DESCRIPTION
changed x-content-type-options to lowercase to see if the value will change

Story: https://qmacbis.atlassian.net/browse/OY2-XXXX
Endpoint: See github-actions bot comment

### Details

Change X-Content-Type-Options  value to lowercase 'nosniff' to see if the value will change in AWS.

### Changes

- Specific functionality changes, or
- A specific bug addressed in this PR

### Implementation Notes

- Developer focused info that may affect future work

### Test Plan

1. Test step 1
2. Test step 2
