### PR TITLE
OY2-28452 - set lambda default timeout to 2.5min

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -71,6 +71,7 @@ custom:
 provider:
   name: aws
   runtime: nodejs20.x
+  timeout: 150
   region: us-east-1
   stage: dev
   iam:
@@ -101,7 +102,6 @@ functions:
   submitInitialWaiver:
     handler: form/submitInitialWaiver.main
     role: LambdaApiRole
-    timeout: 30
     events:
       - http:
           path: submitInitialWaiver
@@ -112,7 +112,6 @@ functions:
   submitMedicaidSpa:
     handler: form/submitMedicaidSPA.main
     role: LambdaApiRole
-    timeout: 30
     events:
       - http:
           path: submitMedicaidSPA
@@ -123,7 +122,6 @@ functions:
   submitMedicaidSpaRaiResponse:
     handler: form/submitMedicaidSPARAIResponse.main
     role: LambdaApiRole
-    timeout: 30
     events:
       - http:
           path: submitMedicaidSPARAIResponse
@@ -134,7 +132,6 @@ functions:
   submitChipSpa:
     handler: form/submitCHIPSPA.main
     role: LambdaApiRole
-    timeout: 30
     environment:
       reviewerEmail: ${self:custom.reviewerCHIPEmail}
       ccEmail: ${self:custom.chipCcEmail}
@@ -148,7 +145,6 @@ functions:
   submitCHIPSPARAIResponse:
     handler: form/submitCHIPSPARAIResponse.main
     role: LambdaApiRole
-    timeout: 30
     environment:
       reviewerEmail: ${self:custom.reviewerCHIPEmail}
       ccEmail: ${self:custom.chipCcEmail}
@@ -162,7 +158,6 @@ functions:
   submitWaiverExtension:
     handler: form/submitWaiverExtension.main
     role: LambdaApiRole
-    timeout: 30
     events:
       - http:
           path: submitWaiverExtension
@@ -173,7 +168,6 @@ functions:
   submitWaiverRaiResponse:
     handler: form/submitWaiverRAIResponse.main
     role: LambdaApiRole
-    timeout: 30
     events:
       - http:
           path: submitWaiverRAIResponse
@@ -184,7 +178,6 @@ functions:
   submitWaiverRenewal:
     handler: form/submitWaiverRenewal.main
     role: LambdaApiRole
-    timeout: 30
     events:
       - http:
           path: submitWaiverRenewal
@@ -195,7 +188,6 @@ functions:
   submitWaiverAmendment:
     handler: form/submitWaiverAmendment.main
     role: LambdaApiRole
-    timeout: 30
     events:
       - http:
           path: submitWaiverAmendment
@@ -206,7 +198,6 @@ functions:
   submitWaiverAppendixK:
     handler: form/submitWaiverAppendixK.main
     role: LambdaApiRole
-    timeout: 30
     events:
       - http:
           path: submitWaiverAppendixK
@@ -217,7 +208,6 @@ functions:
   submitWaiverAppendixKRAIResponse:
     handler: form/submitWaiverAppendixKRAIResponse.main
     role: LambdaApiRole
-    timeout: 30
     events:
       - http:
           path: submitWaiverAppendixKRAIResponse
@@ -348,7 +338,6 @@ functions:
   withdrawInitialWaiver:
     handler: form/withdrawInitialWaiver.main
     role: LambdaApiRole
-    timeout: 30
     environment:
       ccEmail: ${self:custom.dmcoEmail}
     events:
@@ -361,7 +350,6 @@ functions:
   withdrawMedicaidSPA:
     handler: form/withdrawMedicaidSPA.main
     role: LambdaApiRole
-    timeout: 30
     environment:
       ccEmail: ${self:custom.dpoEmail}
     events:
@@ -374,7 +362,6 @@ functions:
   withdrawCHIPSPA:
     handler: form/withdrawCHIPSPA.main
     role: LambdaApiRole
-    timeout: 30
     environment:
       reviewerEmail: ${self:custom.reviewerCHIPEmail}
       ccEmail: ${self:custom.chipCcEmail}
@@ -388,7 +375,6 @@ functions:
   withdrawWaiverRenewal:
     handler: form/withdrawWaiverRenewal.main
     role: LambdaApiRole
-    timeout: 30
     environment:
       ccEmail: ${self:custom.dmcoEmail}
     events:
@@ -401,7 +387,6 @@ functions:
   withdrawWaiverAmendment:
     handler: form/withdrawWaiverAmendment.main
     role: LambdaApiRole
-    timeout: 30
     environment:
       ccEmail: ${self:custom.dmcoEmail}
     events:
@@ -414,7 +399,6 @@ functions:
   withdrawWaiverAppendixK:
     handler: form/withdrawWaiverAppendixK.main
     role: LambdaApiRole
-    timeout: 30
     environment:
       ccEmail: ${self:custom.dhcbsooEmail}
     events:
@@ -427,7 +411,6 @@ functions:
   enableRaiWithdraw:
     handler: form/enableRaiWithdraw.main
     role: LambdaApiRole
-    timeout: 30
     events:
       - http:
           path: enableRaiWithdraw
@@ -438,7 +421,6 @@ functions:
   disableRaiWithdraw:
     handler: form/disableRaiWithdraw.main
     role: LambdaApiRole
-    timeout: 30
     events:
       - http:
           path: disableRaiWithdraw
@@ -449,7 +431,6 @@ functions:
   withdrawRAIResponse:
     handler: form/withdrawRAIResponse.main
     role: LambdaApiRole
-    timeout: 30
     environment:
       osgEmail: ${self:custom.reviewerEmail}
       chipEmail: ${self:custom.reviewerCHIPEmail}
@@ -559,7 +540,6 @@ functions:
   updateUserStatus:
     handler: updateUserStatus.main
     role: LambdaApiRole
-    timeout: 30
     environment:
       userAccessEmailSource: ${self:custom.userAccessEmailSource}
     events:
@@ -572,7 +552,6 @@ functions:
   setUserPhoneNumber:
     handler: putPhoneNumber.main
     role: LambdaApiRole
-    timeout: 30
     events:
       - http:
           path: phoneNumber


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-28452
Endpoint: See github-actions bot comment

### Details

A quick summary of the intended outcome of this PR.

### Changes

- Set default timeout for all lambdas in app-api to two and a half minutes

### Test Plan

1. Verify in console app-api lambdas are set at 2.5 minutes
2. 
<img width="1333" alt="image" src="https://github.com/Enterprise-CMCS/macpro-onemac/assets/99831795/c2517844-7da0-43b6-9a36-1ca4ab449a1d">

