### PR TITLE
continue pipeline even if issues with seed data

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -245,13 +245,18 @@ jobs:
         if: ${{ env.branch_name != 'production'}}
         run: cd services/app-api/seed-data && ./buildSeedData.py .
       - name: Seed Data
-        # this "resets" any data explicitly provided in the seed files to what
-        # is in the committed code
         if: ${{ env.branch_name != 'production' }}
         env:
           SLS_DEBUG: 'true'
           BRANCH: ${{ env.STAGE_PREFIX }}${{ env.branch_name }}
-        run: cd services/app-api && serverless dynamodb seed --stage=$BRANCH --region=$AWS_DEFAULT_REGION --online
+        run: |
+          set +e
+          cd services/app-api
+          serverless dynamodb seed --stage=$BRANCH --region=$AWS_DEFAULT_REGION --online
+          if [ $? -ne 0 ]; then
+            echo "Seed data step failed but continuing with the pipeline."
+          fi
+          set -e
       - name: Load Test Users
         if: ${{ env.branch_name != 'production'}}
         run: ./loadTestUsers.py $STAGE_PREFIX$branch_name


### PR DESCRIPTION
Seed Data issues were preventing the full pipeline to run. We want the pipeline to run even if some seed data fails. This could  affect tests but is a better outcome than tests not running at all given at this point the application has already deployed.