### PR TITLE
ignore email records in package builder

### DIFF
--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -82,8 +82,11 @@ export const buildAnyPackage = async (packageId, config) => {
     let adminChanges = [];
 
     result.Items.forEach((anEvent) => {
-      // we ignore all other v's (for now)
-      if (anEvent.sk.substring(0, 1) === "v") {
+      // we ignore all other v's (for now) and any email events
+      if (
+        anEvent.sk.substring(0, 1) === "v" ||
+        anEvent.sk.startsWith("Email")
+      ) {
         console.log("ignoring: ", anEvent.sk);
         return;
       }


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-28890
Endpoint: See github-actions bot comment

### Details

New package submissions along with secondary actions such as RAI should keep the initial submission date on the package in both the dashboard list and the package detail view.

### Changes

- updated package builder to ignore email records that are created with package submissions, what was occuring was these email records counted as a onemac record and therefor package builder was trying to use them to determine latest data; however since these are nonstandard package records they did not contain all the necessary data and were causing malformed packages

### Implementation Notes

- To Fix already created malformed packages we will need to run package builder in dev/test/prod as it is deployed

