### PR TITLE
oy2-28671 - update subsequent submission additional information text

### DIFF
--- a/services/ui-src/src/libs/formLib.tsx
+++ b/services/ui-src/src/libs/formLib.tsx
@@ -132,6 +132,12 @@ export const defaultOneMACFormConfig = {
   submitInstructionsJSX: defaultSubmitInstructionsJSX,
 };
 
+export const defaultSubsequentSubmissionFormConfig = {
+  ...defaultOneMACFormConfig,
+  addlInfoTitle: "Reason for subsequent submission",
+  addlInfoText: "Explain why additional documents are being submitted.",
+};
+
 export const defaultWaiverAuthority = [
   { label: "-- select a waiver authority --", value: "" },
 ];

--- a/services/ui-src/src/page/chip-spa/ChipSPASubsequentSubmissionForm.tsx
+++ b/services/ui-src/src/page/chip-spa/ChipSPASubsequentSubmissionForm.tsx
@@ -2,8 +2,8 @@ import React, { FC } from "react";
 import OneMACForm from "../OneMACForm";
 import {
   defaultConfirmSubsequentSubmission,
-  defaultOneMACFormConfig,
   defaultSubsequentAttachmentInstructionsJSX,
+  defaultSubsequentSubmissionFormConfig,
   defaultSubsequentSubmissionIntroJSX,
   OneMACFormConfig,
 } from "../../libs/formLib";
@@ -14,7 +14,7 @@ import {
 } from "cmscommonlib";
 
 export const chipSPASubsequentSubmissionFormInfo: OneMACFormConfig = {
-  ...defaultOneMACFormConfig,
+  ...defaultSubsequentSubmissionFormConfig,
   ...chipSPASubsequentSubmission,
   pageTitle: "Upload Subsequent CHIP SPA Documentation",
   detailsHeader: "CHIP SPA Subsequent Submission",

--- a/services/ui-src/src/page/initial-waiver/InitialWaiverSubsequentSubmissionForm.tsx
+++ b/services/ui-src/src/page/initial-waiver/InitialWaiverSubsequentSubmissionForm.tsx
@@ -2,8 +2,8 @@ import React, { FC } from "react";
 import OneMACForm from "../OneMACForm";
 import {
   defaultConfirmSubsequentSubmission,
-  defaultOneMACFormConfig,
   defaultSubsequentAttachmentInstructionsJSX,
+  defaultSubsequentSubmissionFormConfig,
   defaultSubsequentSubmissionIntroJSX,
   OneMACFormConfig,
 } from "../../libs/formLib";
@@ -20,7 +20,7 @@ import { FormLocationState } from "../../domain-types";
 import { useLocation } from "react-router-dom";
 
 export const initialWaiverSubsequentSubmissionFormInfo: OneMACFormConfig = {
-  ...defaultOneMACFormConfig,
+  ...defaultSubsequentSubmissionFormConfig,
   ...initialWaiverSubsequentSubmission,
   pageTitle: "Upload Subsequent Waiver Documentation",
   detailsHeader: "Initial Waiver Subsequent Submission",

--- a/services/ui-src/src/page/medicaid-spa/MedicaidSPASubsequentSubmissionForm.tsx
+++ b/services/ui-src/src/page/medicaid-spa/MedicaidSPASubsequentSubmissionForm.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from "react";
 import OneMACForm from "../OneMACForm";
 import {
+  defaultSubsequentSubmissionFormConfig,
   defaultConfirmSubsequentSubmission,
-  defaultOneMACFormConfig,
   defaultSubsequentAttachmentInstructionsJSX,
   defaultSubsequentSubmissionIntroJSX,
   OneMACFormConfig,
@@ -14,7 +14,7 @@ import {
 } from "cmscommonlib";
 
 export const medicaidSPASubsequentSubmissionFormInfo: OneMACFormConfig = {
-  ...defaultOneMACFormConfig,
+  ...defaultSubsequentSubmissionFormConfig,
   ...medicaidSPASubsequentSubmission,
   pageTitle: "Upload Subsequent Medicaid SPA Documentation",
   detailsHeader: "Medicaid SPA Subsequent Submission",

--- a/services/ui-src/src/page/section/AdditionalInfoSection.tsx
+++ b/services/ui-src/src/page/section/AdditionalInfoSection.tsx
@@ -3,18 +3,27 @@ import React, { FC } from "react";
 
 export const AdditionalInfoSection: FC<{
   additionalInfo: string;
+  isSubSub?: boolean;
   id?: string;
-}> = ({ additionalInfo, id = "addl-info-base" }) => {
+}> = ({ additionalInfo, isSubSub, id = "addl-info-base" }) => {
   return (
     <>
       <section id={id} className="detail-section">
-        <h2>Additional Information</h2>
+        <h2>
+          {isSubSub
+            ? "Reason for subsequent submission"
+            : "Additional Information"}
+        </h2>
         <Review
           className="original-review-component preserve-spacing"
           headingLevel="2"
         >
+          {/* for sub subs' reasons MUST be submitted but just in case I added this switch */}
           {additionalInfo || (
-            <i>No Additional Information has been submitted.</i>
+            <i>
+              No {isSubSub ? "Reason" : "Additional Information"} has been
+              submitted.
+            </i>
           )}
         </Review>
       </section>

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -157,6 +157,7 @@ export const DetailSection = ({
   );
 
   const actions = detail.actions;
+  const subSubType = "Subsequent Documentation Uploaded";
 
   return (
     <>
@@ -266,6 +267,7 @@ export const DetailSection = ({
                       </>
                     )}
                     <AdditionalInfoSection
+                      isSubSub={anEvent.type === subSubType}
                       additionalInfo={anEvent.additionalInformation}
                       id={"addl-info-chrono-" + index}
                     />

--- a/services/ui-src/src/page/waiver-amendment/WaiverAmendmentSubsequentSubmissionForm.tsx
+++ b/services/ui-src/src/page/waiver-amendment/WaiverAmendmentSubsequentSubmissionForm.tsx
@@ -2,8 +2,8 @@ import React, { FC } from "react";
 import OneMACForm from "../OneMACForm";
 import {
   defaultConfirmSubsequentSubmission,
-  defaultOneMACFormConfig,
   defaultSubsequentAttachmentInstructionsJSX,
+  defaultSubsequentSubmissionFormConfig,
   defaultSubsequentSubmissionIntroJSX,
   OneMACFormConfig,
 } from "../../libs/formLib";
@@ -20,7 +20,7 @@ import { FormLocationState } from "../../domain-types";
 import { useLocation } from "react-router-dom";
 
 export const waiverAmendmentSubsequentSubmissionFormInfo: OneMACFormConfig = {
-  ...defaultOneMACFormConfig,
+  ...defaultSubsequentSubmissionFormConfig,
   ...waiverAmendmentSubsequentSubmission,
   pageTitle: "Upload Subsequent Waiver Amendment Documentation",
   detailsHeader: "Waiver Amendment Subsequent Submission",

--- a/services/ui-src/src/page/waiver-appendix-k/WaiverAppKSubsequentSubmissionForm.tsx
+++ b/services/ui-src/src/page/waiver-appendix-k/WaiverAppKSubsequentSubmissionForm.tsx
@@ -2,8 +2,8 @@ import React, { FC } from "react";
 import OneMACForm from "../OneMACForm";
 import {
   defaultConfirmSubsequentSubmission,
-  defaultOneMACFormConfig,
   defaultSubsequentAttachmentInstructionsJSX,
+  defaultSubsequentSubmissionFormConfig,
   defaultSubsequentSubmissionIntroJSX,
   OneMACFormConfig,
 } from "../../libs/formLib";
@@ -14,7 +14,7 @@ import {
 } from "cmscommonlib";
 
 export const waiverAppKSubsequentSubmissionFormInfo: OneMACFormConfig = {
-  ...defaultOneMACFormConfig,
+  ...defaultSubsequentSubmissionFormConfig,
   ...waiverAppKSubsequentSubmission,
   pageTitle: "Upload Subsequent 1915(c) Appendix K Documentation",
   detailsHeader: "1915(c) Appendix K Subsequent Submission",

--- a/services/ui-src/src/page/waiver-renewal/WaiverRenewalSubsequentSubmissionForm.tsx
+++ b/services/ui-src/src/page/waiver-renewal/WaiverRenewalSubsequentSubmissionForm.tsx
@@ -2,8 +2,8 @@ import React, { FC } from "react";
 import OneMACForm from "../OneMACForm";
 import {
   defaultConfirmSubsequentSubmission,
-  defaultOneMACFormConfig,
   defaultSubsequentAttachmentInstructionsJSX,
+  defaultSubsequentSubmissionFormConfig,
   defaultSubsequentSubmissionIntroJSX,
   OneMACFormConfig,
 } from "../../libs/formLib";
@@ -20,7 +20,7 @@ import { FormLocationState } from "../../domain-types";
 import { useLocation } from "react-router-dom";
 
 export const waiverRenewalSubsequentSubmissionFormInfo: OneMACFormConfig = {
-  ...defaultOneMACFormConfig,
+  ...defaultSubsequentSubmissionFormConfig,
   ...waiverRenewalSubsequentSubmission,
   pageTitle: "Upload Subsequent Waiver Renewal Documentation",
   detailsHeader: "Waiver Renewal Subsequent Submission",


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-28671 
Endpoint: See github-actions bot comment

### Details

Change the title and instructional text for the additional information section viewable on the subsequent submission forms for Medicaid Spa, Chip Spa, Initial Waiver, Renewal Waiver, Waiver Amendment, and Waiver app K.

### Changes

- Created `defaultSubsequentSubmissionFormConfig` that extends the original `defaultOneMACFormConfig`
- Updated all subsequent submission forms to extend `defaultSubsequentSubmissionFormConfig`

### Test Plan

1. Login as statesubmitter
2. For each applicable package type (Medicaid Spa, Chip Spa, Initial Waiver, Renewal Waiver, Waiver Amendment, and Waiver app K) locate an existing package in Under Review status
3. Select the Upload Subsequent Documents action either from the dashboard or the package details page
4. Confirm Text appears as required in ACs

<img width="1159" alt="image" src="https://github.com/Enterprise-CMCS/macpro-onemac/assets/99831795/6d9ca59a-2d30-46b3-a170-0719870c7e68">

