### PR TITLE
oy2-28987 - update email notification text to state for sub sub

### DIFF
--- a/services/app-api/email/stateSubsequentSubmissionReceipt.js
+++ b/services/app-api/email/stateSubsequentSubmissionReceipt.js
@@ -6,6 +6,9 @@ import { formatPackageDetails } from "./formatPackageDetails.js";
  * @returns {Object} email parameters in generic format.
  */
 export const stateSubsequentSubmissionReceipt = (data, config) => {
+  // changing config to match the docs in this one instance
+  if (config.idLabel === "SPA ID") config.idLabel = "Medicaid SPA Package ID";
+
   return {
     ToAddresses: [`${data.submitterName} <${data.submitterEmail}>`],
     CcAddresses: [],

--- a/services/app-api/email/stateSubsequentSubmissionReceipt.js
+++ b/services/app-api/email/stateSubsequentSubmissionReceipt.js
@@ -6,10 +6,10 @@ import { formatPackageDetails } from "./formatPackageDetails.js";
  * @returns {Object} email parameters in generic format.
  */
 export const stateSubsequentSubmissionReceipt = (data, config) => {
-  data.attachments = {}; //remove attachments because we dont want them listed in the state email
+  //  ToAddresses: [`${data.submitterName} <${data.submitterEmail}>`],
 
   return {
-    ToAddresses: [`${data.submitterName} <${data.submitterEmail}>`],
+    ToAddresses: [`aswift@fearless.tech`],
     CcAddresses: [],
     Subject: `Additional documents submitted for ${config.typeLabel} ${data.componentId}`,
     HTML: `
@@ -17,8 +17,7 @@ export const stateSubsequentSubmissionReceipt = (data, config) => {
       config.typeLabel
     } ${data.componentId}:</p>
     ${formatPackageDetails(data, config)}
-    <br>
     <p>If you have questions or did not expect this email, please contact <a href="mailto:spa@cms.hhs.gov">SPA@CMS.HHS.gov</a>.</p>
-    <p>Thank you!</p>`,
+    <p>Thank you.</p>`,
   };
 };

--- a/services/app-api/email/stateSubsequentSubmissionReceipt.js
+++ b/services/app-api/email/stateSubsequentSubmissionReceipt.js
@@ -8,11 +8,12 @@ import { formatPackageDetails } from "./formatPackageDetails.js";
 export const stateSubsequentSubmissionReceipt = (data, config) => {
   // changing config to match the docs in this one instance
   if (config.idLabel === "SPA ID") {
-    const typeLabel = config.typeLabel;
+    let typeLabel = config.typeLabel;
     // cut the type label at sub sub and set that at the new idLabel
-    config.idLabel = typeLabel
+    typeLabel = typeLabel
       .substring(0, typeLabel.indexOf("Subsequent Submission"))
       .trim();
+    config.typeLabel = `${typeLabel} Package ID`;
   }
 
   return {

--- a/services/app-api/email/stateSubsequentSubmissionReceipt.js
+++ b/services/app-api/email/stateSubsequentSubmissionReceipt.js
@@ -7,7 +7,13 @@ import { formatPackageDetails } from "./formatPackageDetails.js";
  */
 export const stateSubsequentSubmissionReceipt = (data, config) => {
   // changing config to match the docs in this one instance
-  if (config.idLabel === "SPA ID") config.idLabel = "Medicaid SPA Package ID";
+  if (config.idLabel === "SPA ID") {
+    const typeLabel = config.typeLabel;
+    // cut the type label at sub sub and set that at the new idLabel
+    config.idLabel = typeLabel
+      .substring(0, typeLabel.indexOf("Subsequent Submission"))
+      .trim();
+  }
 
   return {
     ToAddresses: [`${data.submitterName} <${data.submitterEmail}>`],

--- a/services/app-api/email/stateSubsequentSubmissionReceipt.js
+++ b/services/app-api/email/stateSubsequentSubmissionReceipt.js
@@ -13,7 +13,7 @@ export const stateSubsequentSubmissionReceipt = (data, config) => {
     typeLabel = typeLabel
       .substring(0, typeLabel.indexOf("Subsequent Submission"))
       .trim();
-    config.typeLabel = `${typeLabel} Package ID`;
+    config.idLabel = `${typeLabel} Package ID`;
   }
 
   return {

--- a/services/app-api/email/stateSubsequentSubmissionReceipt.js
+++ b/services/app-api/email/stateSubsequentSubmissionReceipt.js
@@ -11,11 +11,11 @@ export const stateSubsequentSubmissionReceipt = (data, config) => {
   return {
     ToAddresses: [`${data.submitterName} <${data.submitterEmail}>`],
     CcAddresses: [],
-    Subject: `Subsequent Documentation for ${config.typeLabel} ${data.componentId}`,
+    Subject: `Additional documents submitted for ${config.typeLabel} ${data.componentId}`,
     HTML: `
-    <p>	This is confirmation that you submitted ${
+    <p>	You’ve successfully submitted the following to CMS reviewers for ${
       config.typeLabel
-    } materials to CMS for review:</p>
+    } ${data.componentId}</p>
     ${formatPackageDetails(data, config)}
     <br>
     <p>If you have questions or did not expect this email, please contact <a href="mailto:spa@cms.hhs.gov">SPA@CMS.HHS.gov</a>.</p>

--- a/services/app-api/email/stateSubsequentSubmissionReceipt.js
+++ b/services/app-api/email/stateSubsequentSubmissionReceipt.js
@@ -15,7 +15,7 @@ export const stateSubsequentSubmissionReceipt = (data, config) => {
     HTML: `
     <p>	You’ve successfully submitted the following to CMS reviewers for ${
       config.typeLabel
-    } ${data.componentId}</p>
+    } ${data.componentId}:</p>
     ${formatPackageDetails(data, config)}
     <br>
     <p>If you have questions or did not expect this email, please contact <a href="mailto:spa@cms.hhs.gov">SPA@CMS.HHS.gov</a>.</p>

--- a/services/app-api/email/stateSubsequentSubmissionReceipt.js
+++ b/services/app-api/email/stateSubsequentSubmissionReceipt.js
@@ -6,10 +6,8 @@ import { formatPackageDetails } from "./formatPackageDetails.js";
  * @returns {Object} email parameters in generic format.
  */
 export const stateSubsequentSubmissionReceipt = (data, config) => {
-  //  ToAddresses: [`${data.submitterName} <${data.submitterEmail}>`],
-
   return {
-    ToAddresses: [`aswift@fearless.tech`],
+    ToAddresses: [`${data.submitterName} <${data.submitterEmail}>`],
     CcAddresses: [],
     Subject: `Additional documents submitted for ${config.typeLabel} ${data.componentId}`,
     HTML: `


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-28987
Endpoint: https://dhvpvkjk6qdsw.cloudfront.net

### Details

Text change to the emails sent out to state when a sub sub event occurs

### Changes

- text in stateSubsequentSubmissionReceipt

### Test Plan

1. Login as statesubmitter 
2. Find any package of any type (Medicaid Spa, Chip Spa, Initial Waiver, Amendment Waiver, Renewal Waiver, Waiver App K) and select Upload Subsequent Documents action.
3. Fill out required fields and submit
4. Verify the text in the email to the state user matches the AC

<img width="1112" alt="Screenshot 2024-07-12 at 1 00 39 PM" src="https://github.com/user-attachments/assets/b13c4214-7180-43b8-b5c6-d0eda7b30444">
