### PR TITLE
oy2-28988 - update email notification text to CMS for sub sub 

### DIFF
--- a/services/app-api/email/CMSSubsequentSubmissionNotice.js
+++ b/services/app-api/email/CMSSubsequentSubmissionNotice.js
@@ -16,10 +16,8 @@ export const CMSSubsequentSubmissionNotice = async (data, config) => {
 
   CMSEmailItem?.cpocEmail && ToAddresses.push(CMSEmailItem.cpocEmail);
 
-  // ToAddresses: ToAddresses,
-
   return {
-    ToAddresses: ["aswift@fearless.tech"],
+    ToAddresses: ToAddresses,
     CcAddresses: [],
     Subject: `Action required: review new documents for ${config.typeLabel} ${data.componentId}`,
     HTML: `

--- a/services/app-api/email/CMSSubsequentSubmissionNotice.js
+++ b/services/app-api/email/CMSSubsequentSubmissionNotice.js
@@ -18,15 +18,16 @@ export const CMSSubsequentSubmissionNotice = async (data, config) => {
   return {
     ToAddresses: ToAddresses,
     CcAddresses: [],
-    Subject: `Subsequent Documentation for ${config.typeLabel} ${data.componentId}`,
+    Subject: `Action required: review new documents for ${config.typeLabel} ${data.componentId}`,
     HTML: `
-        <p>The OneMAC Submission Portal received subsequent documentation materials for this ${
-          config.typeLabel
-        }:</p>
-        <ul>
+        <p>New documents have been submitted for ${config.typeLabel} ${
+      data.componentId
+    } in OneMAC.</p>
+        ${formatPackageDetails(data, config)}
+        <br>
+         <ul>
             <li>
-            The submission can be accessed in the OneMAC application, which you can
-            find at <a href="${
+            These documents can be found in OneMAC through <a href="${
               process.env.applicationEndpoint
             }/dashboard">this link</a>.
             </li>
@@ -41,8 +42,6 @@ export const CMSSubsequentSubmissionNotice = async (data, config) => {
             its details by clicking on its ID number.
             </li>
         </ul>
-        ${formatPackageDetails(data, config)}
-        <br>
         <p>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
         <p>Thank you!</p>
         `,

--- a/services/app-api/email/CMSSubsequentSubmissionNotice.js
+++ b/services/app-api/email/CMSSubsequentSubmissionNotice.js
@@ -18,7 +18,7 @@ export const CMSSubsequentSubmissionNotice = async (data, config) => {
   // ToAddresses: ToAddresses,
 
   return {
-    ToAddresses: "aswift@fearless.tech",
+    ToAddresses: ["aswift@fearless.tech"],
     CcAddresses: [],
     Subject: `Action required: review new documents for ${config.typeLabel} ${data.componentId}`,
     HTML: `

--- a/services/app-api/email/CMSSubsequentSubmissionNotice.js
+++ b/services/app-api/email/CMSSubsequentSubmissionNotice.js
@@ -7,6 +7,7 @@ import { getCPOCandSRTEmailAddresses } from "../utils/getCpocAndSrtEmail.js";
  * @returns {Object} email parameters in generic format.
  */
 export const CMSSubsequentSubmissionNotice = async (data, config) => {
+  data.submitterName = ""; // remove this bc we dont want it on the cms email
   const CMSEmailItem = await getCPOCandSRTEmailAddresses(data.componentId);
 
   const ToAddresses = CMSEmailItem.reviewTeamEmailList

--- a/services/app-api/email/CMSSubsequentSubmissionNotice.js
+++ b/services/app-api/email/CMSSubsequentSubmissionNotice.js
@@ -15,6 +15,8 @@ export const CMSSubsequentSubmissionNotice = async (data, config) => {
     : [];
 
   CMSEmailItem?.cpocEmail && ToAddresses.push(CMSEmailItem.cpocEmail);
+  // change the config idLabel to match the docs in this instance
+  if (config.idLabel === "SPA ID") config.idLabel = "Medicaid SPA Package ID";
 
   return {
     ToAddresses: ToAddresses,

--- a/services/app-api/email/CMSSubsequentSubmissionNotice.js
+++ b/services/app-api/email/CMSSubsequentSubmissionNotice.js
@@ -26,7 +26,7 @@ export const CMSSubsequentSubmissionNotice = async (data, config) => {
       data.componentId
     } in OneMAC.</p>
         ${formatPackageDetails(data, config)}
-        <br>
+        <p><b>How to access:</b></p>
          <ul>
             <li>
             These documents can be found in OneMAC through <a href="${
@@ -44,6 +44,7 @@ export const CMSSubsequentSubmissionNotice = async (data, config) => {
             its details by clicking on its ID number.
             </li>
         </ul>
+        <br>
         <p>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
         <p>Thank you!</p>
         `,

--- a/services/app-api/email/CMSSubsequentSubmissionNotice.js
+++ b/services/app-api/email/CMSSubsequentSubmissionNotice.js
@@ -15,8 +15,10 @@ export const CMSSubsequentSubmissionNotice = async (data, config) => {
 
   CMSEmailItem?.cpocEmail && ToAddresses.push(CMSEmailItem.cpocEmail);
 
+  // ToAddresses: ToAddresses,
+
   return {
-    ToAddresses: ToAddresses,
+    ToAddresses: "aswift@fearless.tech",
     CcAddresses: [],
     Subject: `Action required: review new documents for ${config.typeLabel} ${data.componentId}`,
     HTML: `


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-28988
Endpoint: https://d2mq9qmwdyg0k4.cloudfront.net/

### Details

Text change to the emails sent out to CMS when a sub sub event occurs

### Changes

- text in CMSSubsequentSubmissionReceipt

### Test Plan

1. Login as statesubmitter 
2. Find any package of any type (Medicaid Spa, Chip Spa, Initial Waiver, Amendment Waiver, Renewal Waiver, Waiver App K) and select Upload Subsequent Documents action.
3. Fill out required fields and submit
4. Verify the text in the email to the CMS user matches the AC

<img width="1114" alt="Screenshot 2024-07-12 at 12 06 40 PM" src="https://github.com/user-attachments/assets/b0fe1a6f-6ca2-4fb0-80c1-cf33af482d01">

