### PR TITLE
oy2-28672 - update sub sub confirmation popup text

### DIFF
--- a/services/ui-src/src/libs/formLib.tsx
+++ b/services/ui-src/src/libs/formLib.tsx
@@ -175,19 +175,12 @@ export const defaultConfirmSubmitMessageSubsequentSubmission = (
 );
 
 export const defaultConfirmSubsequentSubmission: ConfirmSubmitType = {
-  confirmSubmitHeading: "",
+  confirmSubmitHeading: "OneMAC only for document submission",
   confirmSubmitMessage: (
-    <>
-      <p>
-        <b>Please Note:</b> OneMAC is solely for file submission purposes.
-      </p>
-      <p>
-        <b>
-          Communication between State and CMS users will be completed offline
-        </b>{" "}
-        through email.
-      </p>
-    </>
+    <p>
+      States and CMS reviewers will communicate about the submission through
+      email.
+    </p>
   ),
 };
 


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-28672
Endpoint: See github-actions bot comment

### Details

Simple update to text in confirmation popup for a subsequent submission

### Changes

- Updated defaultConfirmSubsequentSubmission with requested text. This will propogate to all subsequent submission forms.

### Test Plan

1. Login as statesubmitter
2. Find any package of any type (Medicaid Spa, Chip Spa, Initial Waiver, Amendment Waiver, Renewal Waiver, Waiver App K) and select Upload Subsequent Documents action.
3. Fill out required fields and submit
4. Verify text in popup matches the AC

![image](https://github.com/Enterprise-CMCS/macpro-onemac/assets/99831795/bc2d5e0f-76f0-41fe-af69-ff3ea80640fd)
