### PR TITLE
added same text change from the other broken branch

### DIFF
--- a/services/ui-src/src/libs/alertLib.ts
+++ b/services/ui-src/src/libs/alertLib.ts
@@ -40,8 +40,8 @@ export const ALERTS_MSG: Record<
   // Success
   SUBSEQUENT_SUBMISSION_SUCCESS: {
     type: ALERT_TYPES.SUCCESS,
-    heading: "Attachments have been successfully submitted.",
-    text: "If CMS needs any additional information, they will follow up by email.",
+    heading: "Documents submitted",
+    text: "CMS reviewers will follow up by email if additional information is needed.",
   },
 
   WITHDRAW_REQUESTED: {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-28685
Endpoint: (https://d1lftirtv2mkwl.cloudfront.net/)

### Details

Made a change to the alert text/header as per JIRA card: OY2-28685 

### Changes

    heading: Attachments have been successfully submitted -> Documents submitted

    text: If CMS needs any additional information, they will follow up by email -> CMS reviewers will follow up by email if additional information is needed

### Test Plan

tested manually using feature branch deploy. see screenshot: 

<img width="1512" alt="Screenshot 2024-07-12 at 11 15 45 AM" src="https://github.com/user-attachments/assets/23b2706b-b603-4741-8362-97f72762426e">
