### PR TITLE
oy2-29115 - update package builder to set inactivated status on package

### DIFF
--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -80,6 +80,7 @@ export const buildAnyPackage = async (packageId, config) => {
     let showPackageOnDashboard = false;
     let lmTimestamp = 0;
     let adminChanges = [];
+    let packageInactivated = false;
 
     result.Items.forEach((anEvent) => {
       // we ignore all other v's (for now) and any email events
@@ -120,8 +121,10 @@ export const buildAnyPackage = async (packageId, config) => {
       let eventConfig = {};
 
       if (source === "OneMAC") {
-        if (anEvent?.currentStatus === Workflow.ONEMAC_STATUS.INACTIVATED)
+        if (anEvent?.currentStatus === Workflow.ONEMAC_STATUS.INACTIVATED) {
+          packageInactivated = true;
           return;
+        }
         showPackageOnDashboard = true;
 
         // the normalized eventLabel is the GSI1pk without the source and componentType
@@ -336,6 +339,11 @@ export const buildAnyPackage = async (packageId, config) => {
         putParams.Item.adminChanges.push(oneChange);
       }
     });
+
+    //if any submission has been inactivated then override package status
+    if (packageInactivated) {
+      putParams.Item.currentStatus = Workflow.ONEMAC_STATUS.INACTIVATED;
+    }
 
     putParams.Item.lastEventTimestamp = lmTimestamp;
     logIt(JSON.stringify(putParams));


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-29115
Endpoint: See github-actions bot comment

### Details

Package builder was properly setting the package to not display by not setting a GSI key; however the inactivated status was not carrying over.

### Changes

- Updated package builder to track if any OneMac record is marked as currentStatus = Inactivated and if override the package status

### Test Plan

1. Identify a package
2. Run softDeleteComponent lambda
https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/admin-bcf-29115-softDeleteComponent?tab=testing
3. Verify Package record in DB has updated status and that the package no longer appears in the dashboard