### PR TITLE
UI: Notification Card & Banner

### DIFF
--- a/services/ui-src/src/App.tsx
+++ b/services/ui-src/src/App.tsx
@@ -16,6 +16,7 @@ import {
 } from "cmscommonlib";
 import IdleTimerWrapper from "./components/IdleTimerWrapper";
 import { ConfirmationDialog } from "./components/ConfirmationDialog";
+import NotificationBanner from "./components/NotificationBanner";
 
 const DEFAULT_AUTH_STATE: Omit<
   AppContextValue,
@@ -187,10 +188,22 @@ export function App() {
     [authState, setUserInfo, updatePhoneNumber, confirmAction]
   );
 
+  // TODO - Andie DELTE!!
+  const notifications = {
+    header: "MMDL SPA forms available in OneMAC",
+    body: "You can now find PDF forms and implementation guides for Medicaid and CHIP Eligibility SPAs in the FAQs.",
+    date: "Aug 01, 2024",
+    button: {
+      text: "Go to the FAQs",
+      link: "/FAQ",
+    },
+  };
+
   return authState.isAuthenticating ? null : (
     <AppContext.Provider value={contextValue}>
       <IdleTimerWrapper />
       <div className="header-and-content">
+        <NotificationBanner {...notifications} />
         <Header />
         <main id="main">
           <Routes />

--- a/services/ui-src/src/components/MACCard.tsx
+++ b/services/ui-src/src/components/MACCard.tsx
@@ -1,6 +1,5 @@
-import React, { PropsWithChildren, ReactChildren } from "react";
+import React, { PropsWithChildren } from "react";
 import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
-import { Button } from "@cmsgov/design-system";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link } from "react-router-dom";
 import closingX from "../images/ClosingX.svg";
@@ -35,15 +34,6 @@ export type MACCardListProps = PropsWithChildren<{
   legend: string;
   additionalContainerClassName?: string;
 }>;
-export type MACNotificationCardProps = PropsWithChildren<{
-  header: string;
-  body: ReactChildren;
-  date: string;
-  button?: {
-    text: string;
-    link: string;
-  };
-}>;
 
 /** Styled wrapper for use in MACCards, consolidates the use of 'mac-card'
  * css class. */
@@ -57,6 +47,7 @@ export const MACCardWrapper = ({
       <div data-testid="gradient-top" className="mac-card-gradient-top" />
       {children && (
         <div
+          data-testid="MACCard-children"
           className={`${
             withBorder ? "mac-card-border" : ""
           } ${childContainerClassName}`}
@@ -178,39 +169,18 @@ export const MACRemovableCard = ({
 }: MACRemovableCardProps) => {
   return (
     <MACCardWrapper childContainerClassName="mac-card-removable-wrapper">
-      <div>
-        {title && <MACCardTitle title={title} />}
-        {!isReadOnly && hasRoleAccess && renderIf && (
-          <button
-            aria-label={`Self-revoke access to ${title}`}
-            disabled={isReadOnly}
-            onClick={onClick}
-          >
-            <img alt="" className="closing-x" src={closingX} />
-          </button>
-        )}
-      </div>
+      <MACCardTitle title={title} />
+      {!isReadOnly && hasRoleAccess && renderIf && (
+        <button
+          aria-label={`Self-revoke access to ${title}`}
+          disabled={isReadOnly}
+          onClick={onClick}
+        >
+          <img alt="" className="closing-x" src={closingX} />
+        </button>
+      )}
       {description && <span>{description}</span>}
       {children}
-    </MACCardWrapper>
-  );
-};
-
-/** A MACCard for use for notification banners on home screen */
-export const MACNotificationCard = ({
-  header,
-  body,
-  date,
-  button,
-}: MACNotificationCardProps) => {
-  return (
-    <MACCardWrapper>
-      <div>
-        {header && <MACCardTitle title={header} />}
-        {body}
-        {button && <Button href={button.link}>{button.text}</Button>}
-        {date}
-      </div>
     </MACCardWrapper>
   );
 };

--- a/services/ui-src/src/components/NotificationBanner.test.js
+++ b/services/ui-src/src/components/NotificationBanner.test.js
@@ -1,0 +1,65 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import NotificationBanner from "./NotificationBanner";
+
+// Mock the Alert component from @cmsgov/design-system
+jest.mock("@cmsgov/design-system", () => ({
+  Alert: ({ children, className }) => (
+    <div className={className}>{children}</div>
+  ),
+  Button: ({ children, className, href }) => (
+    <a className={className} href={href}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("NotificationBanner", () => {
+  test("renders header and body", () => {
+    render(
+      <NotificationBanner header="Test Header" body="Test body content" />
+    );
+
+    expect(screen.getByText(/Test Header/)).toBeInTheDocument();
+    expect(screen.getByText(/Test body content/)).toBeInTheDocument();
+  });
+
+  test("renders button if provided", () => {
+    render(
+      <NotificationBanner
+        header="Test Header"
+        body="Test body content"
+        button={{ text: "Click Me", link: "http://example.com" }}
+      />
+    );
+
+    const buttonElement = screen.getByText(/Click Me/);
+    expect(buttonElement).toBeInTheDocument();
+    expect(buttonElement).toHaveAttribute("href", "http://example.com");
+  });
+
+  test("does not render button if not provided", () => {
+    render(
+      <NotificationBanner header="Test Header" body="Test body content" />
+    );
+
+    expect(screen.queryByText(/Click Me/)).toBeNull();
+  });
+
+  test("closes the notification when the close button is clicked", () => {
+    render(
+      <NotificationBanner header="Test Header" body="Test body content" />
+    );
+
+    // Ensure the notification is initially visible
+    expect(screen.getByText(/Test Header/)).toBeInTheDocument();
+
+    // Click the close button
+    const closeButton = screen.getByLabelText(/Dismiss alert/);
+    fireEvent.click(closeButton);
+
+    // Ensure the notification is no longer visible
+    expect(screen.queryByText(/Test Header/)).toBeNull();
+  });
+});

--- a/services/ui-src/src/components/NotificationBanner.tsx
+++ b/services/ui-src/src/components/NotificationBanner.tsx
@@ -2,7 +2,9 @@ import React, { useState } from "react";
 import { Alert, Button } from "@cmsgov/design-system";
 import closingX from "../images/AlertClosingX.svg";
 
-const CLOSING_X_IMAGE = <img alt="" className="closing-x" src={closingX} />;
+const CLOSING_X_IMAGE = (
+  <img alt="close-x" className="closing-x" src={closingX} />
+);
 
 interface NotificationBannerProps {
   header: string;
@@ -27,24 +29,36 @@ const NotificationBanner: React.FC<NotificationBannerProps> = (
 
   if (!showNotification) return <></>;
   return (
-    <div className="alert-bar" id="alert-bar">
-      {/* should use cms Alert - informational */}
-      <Alert>
+    <Alert className="notification-alert">
+      <div
+        style={{ width: "100%" }}
+        className="ds-u-display--flex ds-u-justify-content--between"
+      >
         {/* TODO: put in flex, make button black */}
-        <h2 className="s-c-alert__heading">{props.header}</h2>
-        <p className="ds-c-alert__text">{props.body}</p>
-        {props.button && (
-          <Button href={props.button.link}>{props.button.text}</Button>
-        )}
-        <button
-          aria-label={"Dismiss alert"}
-          className="close-button"
-          onClick={close}
-        >
-          {CLOSING_X_IMAGE}
-        </button>
-      </Alert>
-    </div>
+        <div>
+          <h2 className="ds-c-alert__header">{props.header}</h2>
+          <p className="">{props.body}</p>
+        </div>
+        <div>
+          {props.button && (
+            <Button
+              className="ds-u-color--black ds-u-border--dark ds-u-fill--transparent"
+              href={props.button.link}
+            >
+              {props.button.text}
+            </Button>
+          )}
+
+          <button
+            aria-label={"Dismiss alert"}
+            className="ds-u-margin-left--2 ds-u-fill--transparent"
+            onClick={close}
+          >
+            {CLOSING_X_IMAGE}
+          </button>
+        </div>
+      </div>
+    </Alert>
   );
 };
 

--- a/services/ui-src/src/components/NotificationCard.test.js
+++ b/services/ui-src/src/components/NotificationCard.test.js
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { NotificationCard } from "./NotificationCard";
+
+describe("NotificationCard", () => {
+  test("renders header and body", () => {
+    render(
+      <NotificationCard
+        header="Test Header"
+        body="Test body content"
+        date="2024-09-17"
+      />
+    );
+
+    expect(screen.getByText(/Test Header:/)).toBeInTheDocument();
+    expect(screen.getByText(/Test body content/)).toBeInTheDocument();
+  });
+
+  test("renders link if provided", () => {
+    render(
+      <NotificationCard
+        header="Test Header"
+        body="Test body content"
+        date="2024-08-01"
+        link={{ href: "http://example.com", text: "Example Link" }}
+      />
+    );
+
+    const linkElement = screen.getByText(/Example Link/);
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement).toHaveAttribute("href", "http://example.com");
+  });
+
+  test("does not render link when link prop is not provided", () => {
+    render(
+      <NotificationCard
+        header="Test Header"
+        body="Test body content"
+        date="2024-09-17"
+      />
+    );
+
+    expect(screen.queryByText(/Example Link/)).toBeNull();
+  });
+
+  test("renders MACCard with correct props", () => {
+    const { container } = render(
+      <NotificationCard
+        header="Test Header"
+        body="Test body content"
+        date="2024-09-17"
+      />
+    );
+
+    // Check that MACCard is rendered
+    expect(container.querySelector(".mac-card-wrapper")).toBeInTheDocument();
+
+    // Ensure MACCard has the correct props
+    const macCardChildElement = screen.getByTestId("MACCard-children");
+    expect(macCardChildElement).toHaveClass("home-content-full-width");
+    expect(macCardChildElement).toHaveClass("mac-card-border");
+  });
+});

--- a/services/ui-src/src/components/NotificationCard.tsx
+++ b/services/ui-src/src/components/NotificationCard.tsx
@@ -1,0 +1,33 @@
+import React, { PropsWithChildren, ReactChildren } from "react";
+import { MACCard } from "./MACCard";
+import { ExternalLinkIcon } from "@cmsgov/design-system";
+
+export type NotificationCardProps = PropsWithChildren<{
+  header: string;
+  body: ReactChildren;
+  date: string;
+  link?: {
+    text: string;
+    href: string;
+  };
+}>;
+
+export const NotificationCard = ({
+  header,
+  body,
+  date,
+  link,
+}: NotificationCardProps) => {
+  return (
+    <MACCard withBorder childContainerClassName="home-content-full-width">
+      <b className="ds-u-color--primary">{header}: </b>
+      {body}{" "}
+      {link && (
+        <a className="ds-u-color--primary" href={link.href}>
+          {link.text}
+        </a>
+      )}{" "}
+      {link && <ExternalLinkIcon />} {date}
+    </MACCard>
+  );
+};

--- a/services/ui-src/src/containers/Home.js
+++ b/services/ui-src/src/containers/Home.js
@@ -154,7 +154,6 @@ export default function Home() {
     <>
       <HomeHeader />
       <AlertBar alertCode={location?.state?.passCode} />
-
       <div className="home-content-container">
         <h1>State Users</h1>
         <section>

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -1892,6 +1892,10 @@ article.form-container {
     }
   }
 
+  .mac-card-wrapper:has(.home-content-full-width) {
+    width: 100%;
+  }
+
   .mac-card-wrapper {
     width: 40%;
   }
@@ -1940,6 +1944,14 @@ article.form-container {
   .home-content-right-box {
     @extend .ds-l-col--12;
     @extend .ds-u-measure--base;
+  }
+
+  .home-content-full-width {
+    @extend .ds-l-lg-col--12;
+    @extend .ds-u-lg-margin-right--3;
+    @extend .ds-u-margin-bottom--5;
+    @extend .ds-u-lg-margin-bottom--0;
+    @extend .ds-u-padding-bottom--5;
   }
 
   .home-content-left-box {
@@ -2954,4 +2966,8 @@ article.form-container {
 .faqButtonLink {
   @extend .ds-c-button;
   margin: 10px;
+}
+
+.notification-alert .ds-c-alert__body {
+  width: 100%;
 }


### PR DESCRIPTION
Sub task of Story: https://qmacbis.atlassian.net/browse/OY2-20181
Endpoint: See github-actions bot comment

### Mock up
Mock up can be viewed in this Story: https://qmacbis.atlassian.net/browse/OY2-29947
### Changes

- Created new component NotificationBanner 
- Added Card component in with other MAC Cards 

### Implementation Notes

- Have not added context yet
- Created new component for Notification Banner rather than using the Alert because the logic needed in the component is quite different
- The new card component is in it's own file as well under NotificationCard

### Screenshots
Right now, you won't see these on the home screen. I just put it there for testing purposes and removed it on my last commit.

Notification Banner
<img width="1371" alt="Screenshot 2024-09-17 at 3 08 23 PM" src="https://github.com/user-attachments/assets/e6d74b60-791a-4d11-ac1c-560693335236">

Notification Card 
<img width="1087" alt="Screenshot 2024-09-17 at 11 21 39 AM" src="https://github.com/user-attachments/assets/f5234500-bd13-473b-917e-a7d8255cb36e">


