### PR TITLE
trim content before ready check for addl info

### DIFF
--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -316,7 +316,10 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
     );
 
     const isAdditionalInformationReady: boolean = Boolean(
-      formConfig.addlInfoRequired ? oneMacFormData.additionalInformation : true
+      formConfig.addlInfoRequired
+        ? oneMacFormData.additionalInformation &&
+            oneMacFormData.additionalInformation.trim().length > 0
+        : true
     );
 
     setIsSubmissionReady(


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-30169
Endpoint: See github-actions bot comment

### Details

Do not allow empty space characters such as space as a valid entry for the additional information field on subsequent submissions.

### Changes

- updated OneMACForm.tsx to trim the additional information field before checking for validity

### Implementation Notes

- This will affect all forms using the OneMACForm including subsequent submission.

### Test Plan

1. Login as a state submitter
2. Locate a package in Under Review status and initiate the submit subsequent document action
3. Add an attachment and any text in the additional info field.
4. Verify the submit button turns active (green)
5. Remove the additional info text and enter only spaces
6. Verify the submit button stays inactive (grey) and prevents submittal of the form
