### PR TITLE
Discrepancy in file type spelling between FAQ and Upload Subsequent Document screen

### DIFF
--- a/services/ui-src/src/utils/fileTypes.tsx
+++ b/services/ui-src/src/utils/fileTypes.tsx
@@ -11,7 +11,7 @@ export const FILE_TYPES: FileTypeInfo[] = [
   { extension: ".doc", description: "MS Word Document" },
   { extension: ".docx", description: "MS Word Document (xml)" },
   { extension: ".gif", description: "Graphics Interchange Format" },
-  { extension: ".jpeg", description: "Joint Photographic Experts Group" },
+  { extension: ".jpg", description: "Joint Photographic Experts Group" },
   { extension: ".odp", description: "OpenDocument Presentation (OpenOffice)" },
   { extension: ".ods", description: "OpenDocument Spreadsheet (OpenOffice)" },
   { extension: ".odt", description: "OpenDocument Text (OpenOffice)" },


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-30159
Endpoint: https://d2wu5uy3f1bbsf.cloudfront.net/

### Details

> Change .jpeg to .jpg on FAQ page

### Changes

- text change

### Screenshot
<img width="649" alt="Screenshot 2024-10-01 at 2 07 53 PM" src="https://github.com/user-attachments/assets/1bf46a8e-3498-4dac-ac80-6b7cde736997">


### Test Plan

1. Click FAQ page
2. Check under "What kind of files can I upload" to ensure jpeg is now jpeg
