### PR TITLE
Pen Test Fixes: URL encode the email portion

### DIFF
--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -218,7 +218,7 @@ const PackageList = () => {
     ({ value, row }) => (
       <Link
         className="user-name"
-        to={`${ROUTES.PROFILE}/${row.original.submitterEmail}`}
+        to={`${ROUTES.PROFILE}/${window.btoa(row.original.submitterEmail)}`}
       >
         {value}
       </Link>

--- a/services/ui-src/src/containers/UserManagement.js
+++ b/services/ui-src/src/containers/UserManagement.js
@@ -166,7 +166,7 @@ const UserManagement = () => {
     ({ value, row }) => (
       <Link
         className="user-name"
-        to={`${ROUTES.PROFILE}/${row.original.email}`}
+        to={`${ROUTES.PROFILE}/${window.btoa(row.original.email)}`}
       >
         {value}
       </Link>


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-XXXX
Endpoint: https://d16pp7f188p4o4.cloudfront.net/

### Details

- quick fix for pen test finding on the FE
- encoded user email in the URL

### Changes

- encoded the users email with window.btoa
- decoded with window.atob 


https://github.com/user-attachments/assets/872f3cc0-3bfb-4904-965c-543e359213d4


### Implementation Notes

- not really that much more protection, but it is at least a little bit harder
- maybe in the future we should also use a userid instead of their email to query the database

### Test Plan

1. log in as state user, click on another users email on the dashboard to make sure you can still read their profile page
2. try to manually change the URL to something like this: profile/statesystemadminpending@cms.hhs.local and makes sure it goes to "not found"
3. go back to dashboard and click on your own email, and make sure you can still edit your profile. 
