### PR TITLE
Update triageChoices.js

### DIFF
--- a/services/ui-src/src/libs/triageChoices.js
+++ b/services/ui-src/src/libs/triageChoices.js
@@ -41,7 +41,7 @@ export const choicesFromRoute = {
       {
         title:
           "Medicaid Eligibility, Enrollment, Administration, and Health Homes",
-        description: "Redirects to the MACPro Appian submission system",
+        description: "Redirects to the MACPro system",
         linkTo: ROUTES.MEDICAID_ELIGIBILITY_LANDING,
       },
       {


### PR DESCRIPTION
Story: [OY2-31834](https://jiraent.cms.gov/browse/OY2-31834)
Endpoint: See github-actions bot comment

### Details

Small text update to remove reference to appian on choice cards.

### Changes

- Edited triageChoices.js to remove "Appian submission" text

### Test Plan

1. Login as state submitter and click New Submisssion button
2. Select SPA -> Medicaid SPA choice
3. verify Medicaid spa sub choice screen under  "Medicaid Eligibility, Enrollment, Administration, and Health Homes" has subtext of "Redirects to the MACPro system"

![image](https://github.com/user-attachments/assets/7cfb9817-8e19-4974-9a7f-b5bf783b7aef)
